### PR TITLE
Add chatbot service Dockerfile

### DIFF
--- a/chatbot/Dockerfile
+++ b/chatbot/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+WORKDIR /project
+
+## Install uv
+
+# The installer requires curl (and certificates) to download the release archive
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+
+# Download the latest installer
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+
+# Run the installer then remove it
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+# Ensure the installed binary is on the `PATH`
+ENV PATH="/root/.local/bin/:$PATH"
+
+COPY . .
+
+RUN uv pip install --system --no-cache-dir -r service/requirements.txt
+
+WORKDIR /project/service
+
+EXPOSE 8010
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8010", "--reload"]


### PR DESCRIPTION
# Description

Add chatbot service Dockerfile.

```docker
FROM python:3.12-slim

WORKDIR /project

## Install uv

# The installer requires curl (and certificates) to download the release archive
RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates

# Download the latest installer
ADD https://astral.sh/uv/install.sh /uv-installer.sh

# Run the installer then remove it
RUN sh /uv-installer.sh && rm /uv-installer.sh

# Ensure the installed binary is on the `PATH`
ENV PATH="/root/.local/bin/:$PATH"

COPY . .

RUN uv pip install --system --no-cache-dir -r service/requirements.txt

WORKDIR /project/service

EXPOSE 8010

CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8010", "--reload"]
```