### PR TITLE
feat: add slug based routes to products api

### DIFF
--- a/ecom-backend/README.md
+++ b/ecom-backend/README.md
@@ -161,11 +161,14 @@ python scripts/ingest_product_data.py --reset-db \
 
 | Route | Description |
 | --- | --- |
-| `GET /products` | Get all products |
-| `GET /products/{product_id}` | Get a product by ID |
-| `POST /products` | Create a new product |
-| `PUT /products/{product_id}` | Update a product by ID |
-| `DELETE /products/{product_id}` | Delete a product by ID |
+| `GET /products` | Get all products with pagination (page, limit) |
+| `GET /products/search` | Search products with filters (category_id, subcategory_id, product_id, category_slug, subcategory_slug, product_slug, keywords) |
+| `GET /products/id/{product_id}` | Get a product by ID |
+| `GET /products/slug/{product_slug}` | Get a product by slug |
+| `GET /products/category/id/{category_id}` | Get products by category ID |
+| `GET /products/subcategory/id/{subcategory_id}` | Get products by subcategory ID |
+| `GET /products/category/slug/{category_slug}` | Get products by category slug |
+| `GET /products/subcategory/slug/{subcategory_slug}` | Get products by subcategory slug |
 
 | Route | Description |
 | --- | --- |

--- a/ecom-backend/core/exceptions.py
+++ b/ecom-backend/core/exceptions.py
@@ -17,3 +17,8 @@ class ResourceNotFoundException(BaseAppException):
 class UnauthorizedException(BaseAppException):
     def __init__(self, message: str):
         super().__init__(message, status.HTTP_401_UNAUTHORIZED)
+
+class ValidationException(BaseAppException):
+
+    def __init__(self, message: str):
+        super().__init__(message, status.HTTP_422_UNPROCESSABLE_ENTITY)

--- a/ecom-backend/domains/products/api/router.py
+++ b/ecom-backend/domains/products/api/router.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends, Query
 from domains.products.service import ProductService
 from domains.products.schemas import ProductData
 from domains.products.api.dependencies import get_product_service
-
+from domains.products.types import ProductHierarchyFilter, EmptyProductHierarchyFilterError, MultipleProductHierarchyFilterError
+from core.exceptions import ValidationException
 
 router = APIRouter(tags=["products"], prefix="/products")
 
@@ -17,24 +18,97 @@ def get_all_products(
 
 @router.get("/search", response_model=list[ProductData])
 def search(
+    category_id: int | None = Query(None),
+    subcategory_id: int | None = Query(None),
+    product_id: int | None = Query(None),
+
+    category_slug: str | None = Query(None),
+    subcategory_slug: str | None = Query(None),
+    product_slug: str | None = Query(None),
+    keywords: list[str] = Query(None),
+
     page: int = Query(1, ge=1),
     limit: int = Query(10, ge=1),
-    category_id: int = Query(None),
-    subcategory_id: int = Query(None),
-    keywords: list[str] = Query(None),
     service: ProductService = Depends(get_product_service)
 ):
+    try:
+        hier_filter = ProductHierarchyFilter(
+            category_id=category_id,
+            subcategory_id=subcategory_id,
+            product_id=product_id,
+            category_slug=category_slug,
+            subcategory_slug=subcategory_slug,
+            product_slug=product_slug
+        )
+    except EmptyProductHierarchyFilterError:
+        hier_filter = None
+    except MultipleProductHierarchyFilterError as e:
+        raise ValidationException(str(e))
     return service.search(
         page, limit,
-        category_id=category_id,
-        subcategory_id=subcategory_id,
+        hier_filter,
         keywords=keywords
     )
 
 
-@router.get("/{product_id}", response_model=ProductData)
-def get(
+@router.get("/id/{product_id}", response_model=ProductData)
+def get_by_id(
     product_id: int,
     service: ProductService = Depends(get_product_service)
 ):
     return service.get(product_id)
+
+@router.get("/slug/{product_slug}", response_model=ProductData)
+def get_by_slug(
+    product_slug: str,
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1),
+    service: ProductService = Depends(get_product_service)
+):
+    hierarchy_filter = ProductHierarchyFilter(product_slug=product_slug)
+    product = service.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)[0]
+    return product
+
+
+@router.get("/category/id/{category_id}", response_model=list[ProductData])
+def get_by_category_id(
+    category_id: int,
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1),
+    service: ProductService = Depends(get_product_service)
+):
+    hierarchy_filter = ProductHierarchyFilter(category_id=category_id)
+    return service.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)
+
+
+@router.get("/subcategory/id/{subcategory_id}", response_model=list[ProductData])
+def get_by_subcategory_id(
+    subcategory_id: int,    
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1),
+    service: ProductService = Depends(get_product_service)
+):
+    hierarchy_filter = ProductHierarchyFilter(subcategory_id=subcategory_id)
+    return service.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)
+
+
+@router.get("/category/slug/{category_slug}", response_model=list[ProductData])
+def get_by_category_slug(
+    category_slug: str,
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1),
+    service: ProductService = Depends(get_product_service)
+):
+    hierarchy_filter = ProductHierarchyFilter(category_slug=category_slug)
+    return service.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)
+
+
+@router.get("/subcategory/slug/{subcategory_slug}", response_model=list[ProductData])
+def get_by_subcategory_slug(
+    subcategory_slug: str,
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=1),
+    service: ProductService = Depends(get_product_service)
+):
+    hierarchy_filter = ProductHierarchyFilter(subcategory_slug=subcategory_slug)
+    return service.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)

--- a/ecom-backend/domains/products/models.py
+++ b/ecom-backend/domains/products/models.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql import False_
 from core.database import Base
 from sqlalchemy import Integer, Column, String, Float
 from sqlalchemy.sql.sqltypes import TIMESTAMP
@@ -14,6 +15,7 @@ class ProductDB(Base):
     category_id = Column(Integer, nullable=False)
     subcategory_id = Column(Integer, nullable=False)
     name = Column(String, nullable=False)
+    slug = Column(String, nullable=False)
     description = Column(String, nullable=False)
     price = Column(Float, nullable=False)
     created_at = Column(TIMESTAMP(timezone=True), server_default=text("NOW()"), nullable=False)

--- a/ecom-backend/domains/products/repository.py
+++ b/ecom-backend/domains/products/repository.py
@@ -1,14 +1,10 @@
-from domains.products.models import ProductDB
+from domains.products.models import ProductDB, ProductHierarchyDB
 from sqlalchemy.orm import Session
 from abc import ABC, abstractmethod
 from core.exceptions import ResourceNotFoundException
 import sqlalchemy
 from sqlalchemy import func as sql_func
-
-
-class ProductHierarchyFilter:
-    category_id: int
-    subcategory_id: int
+from domains.products.types import ProductHierarchyFilter
 
 class ProductRepository(ABC):
 
@@ -31,9 +27,17 @@ class ProductRepository(ABC):
     @abstractmethod
     def delete(self, product_id: int) -> None:
         pass
+
+    @abstractmethod
+    def get_by_hierarchy(self, hierarchy_filter: ProductHierarchyFilter) -> list[ProductDB]:
+        pass
     
     @abstractmethod
-    def search(self, page: int, limit: int, category_id: int | None = None, subcategory_id: int | None = None, keywords: list[str] = None) -> list[ProductDB]:
+    def search(
+        self, page: int, limit: int, 
+        hierarchy_filter: ProductHierarchyFilter,
+        keywords: list[str] | None = None
+    ) -> list[ProductDB]:
         pass
 
 class SQLAlchemyProductRepository(ProductRepository):
@@ -56,17 +60,30 @@ class SQLAlchemyProductRepository(ProductRepository):
             raise ResourceNotFoundException("No products found")
         return products
 
-    def _get_hierarchy_filter(self, category_id: int | None = None, subcategory_id: int | None = None) -> sqlalchemy.sql.expression.BinaryExpression:
-        hierarchy_filters = []
-        if category_id is not None:
-            hierarchy_filters.append(ProductDB.product_hierarchy.category_id == category_id)
-        if subcategory_id is not None:
-            hierarchy_filters.append(ProductDB.product_hierarchy.subcategory_id == subcategory_id)
+    def _get_hierarchy_sql_filter(self, hierarchy_filter: ProductHierarchyFilter) -> sqlalchemy.sql.expression.BinaryExpression:
 
-        if hierarchy_filters:
-            hierarchy_filter = sqlalchemy.and_(*hierarchy_filters)
-        else:
-            hierarchy_filter = sqlalchemy.true()
+        prod_table_fields = {
+            "category_id": "category_id",
+            "subcategory_id": "subcategory_id",
+            "product_id": "id",
+            "product_slug": "slug"
+        }
+        hier_table_fields = {
+            "category_slug": "category_slug",
+            "subcategory_slug": "subcategory_slug",
+        }
+        hierarchy_filters = []
+
+        for filter_name, filter_value in hierarchy_filter.model_dump(exclude_unset=True).items():
+            if filter_value is not None:
+                if filter_name in prod_table_fields:
+                    f = getattr(ProductDB, prod_table_fields[filter_name])
+                    hierarchy_filters.append(f == filter_value)
+                elif filter_name in hier_table_fields:
+                    kwargs = {hier_table_fields[filter_name]: filter_value}
+                    hierarchy_filters.append(ProductDB.product_hierarchy.has(**kwargs))
+
+        hierarchy_filter = sqlalchemy.and_(*hierarchy_filters)
         return hierarchy_filter
 
     def _get_keyword_filter(self, keywords: list[str] = None) -> sqlalchemy.sql.expression.BinaryExpression:
@@ -81,10 +98,26 @@ class SQLAlchemyProductRepository(ProductRepository):
 
         return keyword_filter
 
-    def search(self, page: int, limit: int, category_id: int | None = None, subcategory_id: int | None = None, keywords: list[str] = None) -> list[ProductDB]:
+    def get_by_hierarchy(self, hierarchy_filter: ProductHierarchyFilter, page: int, limit: int) -> list[ProductDB]:
+        hierarchy_filter = self._get_hierarchy_sql_filter(hierarchy_filter)
+        products = self.db.query(ProductDB).filter(hierarchy_filter).offset((page - 1) * limit).limit(limit).all()
+
+        if not products:
+            raise ResourceNotFoundException("No products found matching the criteria")
+
+        return products
+
+    def search(
+        self, page: int, limit: int, 
+        hierarchy_filter: ProductHierarchyFilter | None = None, 
+        keywords: list[str] = None
+    ) -> list[ProductDB]:
 
         # Build hierarchy filters
-        hierarchy_filter = self._get_hierarchy_filter(category_id, subcategory_id)
+        if hierarchy_filter is not None:
+            hierarchy_filter = self._get_hierarchy_sql_filter(hierarchy_filter)
+        else:
+            hierarchy_filter = sqlalchemy.true()
 
         # Build keyword filters
         keyword_filter = self._get_keyword_filter(keywords)

--- a/ecom-backend/domains/products/service.py
+++ b/ecom-backend/domains/products/service.py
@@ -1,20 +1,24 @@
-from domains.products.repository import SQLAlchemyProductRepository
+from domains.products.repository import ProductRepository
 from domains.products.schemas import ProductData, ProductCreate, ProductUpdate
 from domains.products.models import ProductDB
+from domains.products.types import ProductHierarchyFilter
 
 class ProductService:
 
-    def __init__(self, repo: SQLAlchemyProductRepository):
+    def __init__(self, repo: ProductRepository):
         self.repo = repo
 
     def get(self, product_id: int) -> ProductData:
         return ProductData.model_validate(self.repo.get(product_id))
 
+    def get_by_hierarchy(self, hierarchy_filter: ProductHierarchyFilter, page: int, limit: int) -> list[ProductData]:
+        return [ProductData.model_validate(product_db) for product_db in self.repo.get_by_hierarchy(hierarchy_filter, page=page, limit=limit)]
+
     def get_all(self, page: int, limit: int) -> list[ProductData]:
         return [ProductData.model_validate(product_db) for product_db in self.repo.get_all(page, limit)]
 
-    def search(self, page: int, limit: int, category_id: int | None = None, subcategory_id: int | None = None, keywords: list[str] | None = None) -> list[ProductData]:
-        return [ProductData.model_validate(product_db) for product_db in self.repo.search(page, limit, category_id=category_id, subcategory_id=subcategory_id, keywords=keywords)]
+    def search(self, page: int, limit: int, hierarchy_filter: ProductHierarchyFilter | None = None, keywords: list[str] | None = None) -> list[ProductData]:
+        return [ProductData.model_validate(product_db) for product_db in self.repo.search(page, limit, hierarchy_filter=hierarchy_filter, keywords=keywords)]
 
     def create(self, product_create_data: ProductCreate)-> ProductData:
         product_db = ProductDB(**product_create_data.model_dump())

--- a/ecom-backend/domains/products/types.py
+++ b/ecom-backend/domains/products/types.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, model_validator
+
+class EmptyProductHierarchyFilterError(Exception):
+    pass
+
+class MultipleProductHierarchyFilterError(Exception):
+    pass
+
+class ProductHierarchyFilter(BaseModel):
+    category_id: int | None = None
+    subcategory_id: int | None = None
+    product_id: int | None = None
+
+    category_slug: str | None = None
+    subcategory_slug: str | None = None
+    product_slug: str | None = None
+
+    @model_validator(mode="after")
+    def check_only_one_field_provided(self):
+        if not any(self.model_dump().values()):
+            raise EmptyProductHierarchyFilterError("At least one field must be provided for filter")
+        if len([v for v in self.model_dump().values() if v is not None]) > 1:
+            raise MultipleProductHierarchyFilterError("Only one field can be provided for filter")
+        return self
+

--- a/ecom-backend/notebooks/misc/test_product_api.ipynb
+++ b/ecom-backend/notebooks/misc/test_product_api.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "16dd46d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "APP_ROOT_DIR = \"/Users/Abhishek_Bhatia-GUVA/personal/projects/ecom-shopping-assistant/genai-shopping-assistant/ecom-backend\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7e11f7ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d606b653",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6d0d88a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(APP_ROOT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cac40d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.chdir(APP_ROOT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a166b5aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from domains.products.repository import SQLAlchemyProductRepository\n",
+    "from domains.products.types import ProductHierarchyFilter\n",
+    "from domains.products.models import ProductDB, ProductHierarchyDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a7dd794e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from core.database import get_db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a026c3fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = next(get_db())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1dcfdb06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo = SQLAlchemyProductRepository(db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9ae79bf7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sqlalchemy.sql.elements.BinaryExpression object at 0x107763020>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "repo._get_hierarchy_sql_filter(ProductHierarchyFilter(product_id=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "41192c8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<domains.products.models.ProductDB at 0x11c68f8f0>,\n",
+       " <domains.products.models.ProductDB at 0x11c689070>,\n",
+       " <domains.products.models.ProductDB at 0x11c68fb00>,\n",
+       " <domains.products.models.ProductDB at 0x11c68f410>,\n",
+       " <domains.products.models.ProductDB at 0x11c68f620>,\n",
+       " <domains.products.models.ProductDB at 0x11c68f710>,\n",
+       " <domains.products.models.ProductDB at 0x11c68fa40>,\n",
+       " <domains.products.models.ProductDB at 0x11c68ea50>,\n",
+       " <domains.products.models.ProductDB at 0x11c68fc50>,\n",
+       " <domains.products.models.ProductDB at 0x11c68f680>]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "repo.get_by_hierarchy(\n",
+    "    ProductHierarchyFilter(category_id=1),\n",
+    "    page=1,\n",
+    "    limit=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "19f1500f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "domains.products.models.ProductDB"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ProductDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "9480f5ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<domains.products.models.ProductDB at 0x11c6651f0>,\n",
+       " <domains.products.models.ProductDB at 0x11c665d30>,\n",
+       " <domains.products.models.ProductDB at 0x11c665d60>,\n",
+       " <domains.products.models.ProductDB at 0x11c665a30>,\n",
+       " <domains.products.models.ProductDB at 0x11c6663c0>,\n",
+       " <domains.products.models.ProductDB at 0x11c665580>,\n",
+       " <domains.products.models.ProductDB at 0x11c666390>,\n",
+       " <domains.products.models.ProductDB at 0x11c666420>,\n",
+       " <domains.products.models.ProductDB at 0x11c666000>,\n",
+       " <domains.products.models.ProductDB at 0x11c666120>]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "repo.get_by_hierarchy(\n",
+    "    ProductHierarchyFilter(category_slug=\"jewelry\"),\n",
+    "    page=1,\n",
+    "    limit=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "5c3f40a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "product_db_list = repo.search(\n",
+    "    page=1,\n",
+    "    limit=10,\n",
+    "    hierarchy_filter=ProductHierarchyFilter(category_slug=\"jewelry\"),\n",
+    "    keywords=[\"ring\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "8b885934",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "BaseModel.model_validate() missing 1 required positional argument: 'obj'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[24]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mProductHierarchyFilter\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmodel_validate\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[31mTypeError\u001b[39m: BaseModel.model_validate() missing 1 required positional argument: 'obj'"
+     ]
+    }
+   ],
+   "source": [
+    "ProductHierarchyFilter.model_validate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "09b6d0f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from domains.products.schemas import ProductData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "fe439cec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ProductData(id=1, name='Southwest Bracelet', description=\"The Southwest Bracelet combines elegance with a touch of American Indian glamour. This jeweled bracelet is perfect for making a statement at any occasion, whether you're at a luncheon or an evening out. The bracelet is crafted from high-quality crystals and natural stones, offering a lightweight and comfortable fit. The bracelet is a sparkling accent, catching the light and adding a touch of style.  Pair this accessory with a chic white blouse and a tailored skirt for a polished look, or dress it down with jeans for an elevated everyday style.\", price=169.99, category_id=4, subcategory_id=2)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ProductData.model_validate(product_db_list[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv-ecom-b",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description

Add slug based routes to the following routes to products api:

| Route | Description |
| --- | --- |
| `GET /products` | Get all products with pagination (page, limit) |
| `GET /products/search` | Search products with filters (category_id, subcategory_id, product_id, category_slug, subcategory_slug, product_slug, keywords) |
| `GET /products/id/{product_id}` | Get a product by ID |
| `GET /products/slug/{product_slug}` | Get a product by slug |
| `GET /products/category/id/{category_id}` | Get products by category ID |
| `GET /products/subcategory/id/{subcategory_id}` | Get products by subcategory ID |
| `GET /products/category/slug/{category_slug}` | Get products by category slug |
| `GET /products/subcategory/slug/{subcategory_slug}` | Get products by subcategory slug |