### PR TITLE
fix: fix delete and update routes in carts api

### DIFF
--- a/ecom-backend/domains/carts/api/router.py
+++ b/ecom-backend/domains/carts/api/router.py
@@ -35,12 +35,12 @@ def create_cart(
     return cart_service.create(cart, user.id)
     
 
-@router.delete("/{cart_id}", status_code=status.HTTP_200_OK, dependencies=[Depends(get_current_user)])
+@router.delete("/{cart_id}", response_model=CartData, status_code=status.HTTP_200_OK, dependencies=[Depends(get_current_user)])
 def delete_cart(
     cart_id: int,
     service: CartService = Depends(get_cart_service),
 ):
-    return service.delete_cart(cart_id)
+    return service.delete(cart_id)
 
 @router.put("/{cart_id}", response_model=CartData, status_code=status.HTTP_200_OK, dependencies=[Depends(get_current_user)])
 def update_cart(cart_id: int, cart: CartUpdate, service: CartService = Depends(get_cart_service)):

--- a/ecom-backend/domains/carts/repository.py
+++ b/ecom-backend/domains/carts/repository.py
@@ -60,6 +60,10 @@ class SQLAlchemyCartRepository(CartRepository):
     def delete(self, cart_id: int) -> None:
         self.db.query(CartDB).filter(CartDB.id == cart_id).delete()
         self.db.commit()
+
+    def empty_cart(self, cart_id: int) -> None:
+        self.db.query(CartItemDB).filter(CartItemDB.cart_id == cart_id).delete()
+        self.db.commit()
     
 
     

--- a/ecom-backend/domains/carts/service.py
+++ b/ecom-backend/domains/carts/service.py
@@ -69,6 +69,10 @@ class CartService:
         saved_cart = self.repo.create(cart_db, user_id)
         return CartData.model_validate(saved_cart)
 
+    def empty_cart(self, cart_id: int) -> CartData:
+        self.repo.empty_cart(cart_id)
+        return self.get(cart_id)
+
     def update(self, cart_update_data: CartUpdate, cart_id: int) -> CartData:
         self.empty_cart(cart_id)
         cart_db = self.repo.get(cart_id)
@@ -80,8 +84,10 @@ class CartService:
 
         return CartData.model_validate(updated_cart)
 
-    def delete(self, cart_id: int) -> None:
+    def delete(self, cart_id: int) -> CartData:
+        cart = self.get(cart_id)
         self.repo.delete(cart_id)
+        return cart
         
 
 


### PR DESCRIPTION
# Description


Fix multiple bugs:

- #54 
- #53 

Below is opinionated (might need to research best practice):

(summary generated with windsurf)

Prompt:

```
@router.py @service.py @repository.py Check these 3 files, and get output types for delete, update methods. Get summary in a markdown table format. Keep it brief
```

| Layer | Delete | Update | Empty Cart |
|-------|--------|--------|------------|
| **Router** | **Output:** `CartData` (cart before deletion) | **Output:** `CartData` (updated cart) | N/A |
| **Service** | **Output:** `CartData` (cart before deletion) | **Output:** `CartData` (updated cart) | **Output:** `CartData` (cart after emptying) |
| **Repository** | **Output:** `None` | **Output:** `CartDB` (updated cart) | **Output:** `None` |



