### PR TITLE
fix: products api get product response include product slug

### DIFF
--- a/ecom-backend/domains/products/schemas.py
+++ b/ecom-backend/domains/products/schemas.py
@@ -3,8 +3,10 @@ from pydantic import BaseModel, model_validator
 
 # Input Schemas
 
+# TODO: Make slug creation server side logic (with optional override)
 class ProductCreate(BaseModel):
     name: str
+    slug: str
     description: str
     price: float
     category_id: int
@@ -15,6 +17,7 @@ class ProductCreate(BaseModel):
 
 class ProductUpdate(BaseModel):
     name: str | None = None
+    slug: str | None = None
     description: str | None = None
     price: float | None = None
     category_id: int | None = None
@@ -37,6 +40,7 @@ class ProductUpdate(BaseModel):
 class ProductData(BaseModel):
     id: int
     name: str
+    slug: str
     description: str
     price: float
     category_id: int


### PR DESCRIPTION
# Description


Now contains `slug`

```json
{
    "id": 1,
    "name": "Southwest Bracelet",
    "slug": "southwest-bracelet",
    "description": "The Southwest Bracelet combines elegance with a touch of American Indian glamour. This jeweled bracelet is perfect for making a statement at any occasion, whether you're at a luncheon or an evening out. The bracelet is crafted from high-quality crystals and natural stones, offering a lightweight and comfortable fit. The bracelet is a sparkling accent, catching the light and adding a touch of style.  Pair this accessory with a chic white blouse and a tailored skirt for a polished look, or dress it down with jeans for an elevated everyday style.",
    "price": 169.99,
    "category_id": 4,
    "subcategory_id": 2
}

```


Need to think about how to also return slugs for category, subcategory