### PR TITLE
Fix broken chatbot service to now use `EcomAPIClient` instead of `user_id`

### DIFF
--- a/chatbot/pkg/chatbot/chat.py
+++ b/chatbot/pkg/chatbot/chat.py
@@ -32,8 +32,6 @@ class Chat:
         self.graph = self._build_graph(agents=self.agents, memory=self.memory)
         self.set_thread("1")
     
-    def _inner_thread_id(self):
-        return f'{self.user_id}_{self.thread_id}'
 
     def set_thread(self, thread_id: str):
         self.thread_id = thread_id

--- a/chatbot/service/app.py
+++ b/chatbot/service/app.py
@@ -7,6 +7,9 @@ from chatbot.env import load_env
 import weaviate
 import os
 
+from chatbot.external.ecom_api_client.client import EcomAPIClient
+from chatbot.external.ecom_api_client.credentials import Credentials as EcomAPICredentials
+
 
 VERSION = "0.1.0"
 
@@ -28,9 +31,10 @@ CHATS = {}
 CONF_PATH = "../conf/config.yml"
 
 CONFIG = load_config(CONF_PATH)
+ECOM_API_BASE_URL = os.getenv("ECOM_API_BASE_URL", "http://localhost:8000/api/v1")
 
 
-def initialize_chat(user_id: str):
+def initialize_chat(user_id: str, thread_id: str):
     weaviate_connection_params = weaviate.connect.ConnectionParams(
         http={
             "host": os.getenv("WEAVIATE_HTTP_HOST"),
@@ -48,11 +52,23 @@ def initialize_chat(user_id: str):
         connection_params=weaviate_connection_params
     )
 
-    CHATS[user_id] = Chat(
-        user_id=user_id,
-        config=CONFIG,
-        weaviate_client=weaviate_client
+    chat_id = (user_id, thread_id)
+
+    ecom_api_client = EcomAPIClient(
+        base_url=ECOM_API_BASE_URL,
+        credentials=EcomAPICredentials(
+            user_id=user_id
+        )
     )
+
+    CHATS[chat_id] = Chat(
+        config=CONFIG,
+        weaviate_client=weaviate_client,
+        ecom_api_client=ecom_api_client
+    )
+    CHATS[chat_id].set_thread(thread_id)
+
+
 
 
 class Request(BaseModel):
@@ -62,12 +78,13 @@ class Request(BaseModel):
 
 @app.post("/chat")
 async def chat(request: Request):
-    chat = CHATS.get(request.user_id)
-    if not chat:
-        initialize_chat(request.user_id)
 
-    chat = CHATS[request.user_id]
-    chat.set_thread(request.thread_id)
+    chat_id = (request.user_id, request.thread_id)
+    chat = CHATS.get(chat_id)
+    if not chat:
+        initialize_chat(request.user_id, request.thread_id)
+
+    chat = CHATS[chat_id]
     
     response = await chat.query(request.query)
     return {"response": response}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,14 +37,17 @@ services:
     ports:
       - "8010:8010"
     environment:
-      OPENAI_BASE_URL: xxx
-      OPENAI_API_KEY: xxx
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
       WEAVIATE_HTTP_HOST: weaviate
       WEAVIATE_HTTP_PORT: 8080
       WEAVIATE_HTTP_SECURE: false
       WEAVIATE_GRPC_HOST: weaviate
       WEAVIATE_GRPC_PORT: 50051
       WEAVIATE_GRPC_SECURE: false
+
+      # Accessing the ECOM API running on host machine from the chatbot container
+      ECOM_API_BASE_URL: http://host.docker.internal:8000/api/v1
 
 
 volumes:

--- a/notebooks/misc/test_weaviate_connection.ipynb
+++ b/notebooks/misc/test_weaviate_connection.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 2,
    "id": "c520e53a",
    "metadata": {},
    "outputs": [],
@@ -13,17 +13,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9a621819",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<weaviate.client.WeaviateClient at 0x10a8fb530>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "weaviate.connect_to_local()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "id": "ccd74026",
    "metadata": {},
    "outputs": [],
@@ -44,81 +55,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 5,
+   "id": "891d1898",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chatbot.product_retrieval import retrieve_products"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d56e4513",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "QueryReturn(objects=[Object(uuid=_WeaviateUUIDInt('a3bb4e00-fbff-42c7-b1e7-ae2431fbea4a'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'created_at': '2025-12-02 09:27:59', 'subcategory_name': 'shoes', 'slug': 'yellow-leather-ankle-boots', 'category_slug': 'footwear', 'category_name': 'footwear', 'description': 'The Yellow Leather Ankle Boots are a stylish and comfortable choice for any occasion. These ankle boots feature a sleek yellow leather exterior that adds a vibrant pop of color to any outfit. The pointed toe design and slightly elevated 1.5-inch heel provide a modern touch, while the leather lining ensures a snug and cozy fit. The durable sole is made from rubber, offering excellent traction and support. Perfect for both casual and dressy settings, these boots can be dressed up with a skirt and heels or paired with jeans for a more casual look. The timeless design makes them a versatile addition to any shoe collection.', 'subcategory_slug': 'shoes', 'price': 39.99, 'name': 'Yellow Leather Ankle Boots', 'product_id': 60}, references=None, vector={}, collection='Products'), Object(uuid=_WeaviateUUIDInt('802c5e8c-bd6b-43ba-abe3-fbe48aed444c'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'subcategory_name': 'shoes', 'created_at': '2025-12-02 09:27:59', 'slug': 'havana-heeled-sandals', 'category_slug': 'footwear', 'category_name': 'footwear', 'description': 'The Havana Heeled Sandals are a stylish blend of comfort and elegance, perfect for adding a touch of sophistication to any outfit. These heeled sandals feature a sleek, closed-toe design with a modern Havana brown leather upper, offering a luxurious look that complements both casual and formal attire. The heel height is a comfortable 3 inches, providing a subtle lift without compromising on comfort. The padded insole ensures all-day support, while the lightweight sole provides flexibility and a smooth stride. The open-back design allows for easy slip-on and off, making these sandals convenient for daily wear. Pair them with jeans and a blouse for a casual look, or dress them up with a skirt for a more formal ensemble. The Havana Heeled Sandals are a versatile addition to any footwear collection.', 'subcategory_slug': 'shoes', 'price': 49.99, 'name': 'Havana Heeled Sandals', 'product_id': 72}, references=None, vector={}, collection='Products'), Object(uuid=_WeaviateUUIDInt('80e87cbc-47e1-4a2d-bec4-4e78648fb485'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'created_at': '2025-12-02 09:27:59', 'subcategory_name': 'shoes', 'slug': 'yantra-leather-ankle-boots', 'category_slug': 'footwear', 'category_name': 'footwear', 'description': \"The Yantra Leather Ankle Boots are a chic and stylish addition to any wardrobe, combining modern design with classic comfort. These sleek ankle boots feature a clean, minimalist silhouette that's perfect for both casual and dressy occasions. The 1-inch stacked heel adds a touch of height and elegance without sacrificing comfort, making them ideal for all-day wear. Crafted from high-quality leather, these boots offer a smooth and luxurious feel, with a durable construction that ensures longevity. The leather lining adds an extra layer of comfort, while the rubber outsole provides excellent traction. Whether you're running errands or attending a social event, the Yantra Leather Ankle Boots are the perfect choice for a polished look.\", 'subcategory_slug': 'shoes', 'price': 109.99, 'name': 'Yantra Leather Ankle Boots', 'product_id': 112}, references=None, vector={}, collection='Products'), Object(uuid=_WeaviateUUIDInt('fb62ac39-c61e-45c2-8023-a35e22d73cf9'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'created_at': '2025-12-02 09:27:59', 'subcategory_name': 'shoes', 'category_slug': 'footwear', 'slug': 'jade-suede-heels', 'category_name': 'footwear', 'description': 'The Jade Suede Heels are a luxurious blend of comfort and style, perfect for adding a touch of elegance to any outfit. These heeled shoes feature a sleek, pointed toe design that exudes sophistication, complemented by a vibrant jade green suede upper that adds a pop of color to any ensemble. The 3-inch heel height provides a subtle lift without compromising comfort, while the cushioned insole ensures all-day support. The open-back design offers easy slip-on convenience, making them ideal for both casual outings and formal events. The suede material adds a rich texture and a touch of luxury, making these heels a versatile addition to your footwear collection. Pair them with a pencil skirt and blouse for a polished look, or dress them up with a flowing dress for a glamorous evening.', 'name': 'Jade Suede Heels', 'price': 189.99, 'subcategory_slug': 'shoes', 'product_id': 49}, references=None, vector={}, collection='Products'), Object(uuid=_WeaviateUUIDInt('56db6a5e-7121-489e-b053-efdd809bf0ee'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'created_at': '2025-12-02 09:27:59', 'subcategory_name': 'shoes', 'category_slug': 'footwear', 'slug': 'sleek-stiletto-heels-in-navy', 'category_name': 'footwear', 'description': 'The Sleek Stiletto Heels in Navy are a perfect blend of sophistication and elegance, designed to elevate any outfit with their sharp and stylish presence. These heeled shoes feature a sleek closed toe design, providing a modern and refined look. The navy color adds a timeless touch, making them versatile enough for both casual and formal settings.\\n\\nWith a striking heel height of 4 inches, these shoes offer a dramatic and elegant silhouette. The sturdy and comfortable sole is crafted from high-quality polyurethane, providing excellent support and a stable stride throughout the day. The insole, made from a combination of 78% polyurethane and 22% polyester, adds additional cushioning for all-day comfort.\\n\\nThe navy hue of these shoes pairs beautifully with a variety of outfits, from a little black dress to tailored trousers. Their sleek design makes them a stylish addition to any wardrobe, perfect for both professional and social occasions.', 'subcategory_slug': 'shoes', 'price': 89.99, 'name': 'Sleek Stiletto Heels in Navy', 'product_id': 51}, references=None, vector={}, collection='Products')])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "retrieve_products(\n",
+    "    query=\"footwear\",\n",
+    "    n=5,\n",
+    "    # weaviate_client=weaviate_client\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "2acffb48",
    "metadata": {},
    "outputs": [],
    "source": [
     "client = weaviate.WeaviateClient(connection_params)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "e7cf9ef4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class WeaviateConnectionManager:\n",
-    "\n",
-    "    def __init__(self, client: WeaviateClient):\n",
-    "        self.client = client\n",
-    "\n",
-    "    def __enter__(self) -> WeaviateClient:\n",
-    "        self.client.connect()\n",
-    "        return self.client\n",
-    "\n",
-    "    def __exit__(self, exc_type, exc_val, exc_tb):\n",
-    "        self.client.close()\n",
-    "\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "5e78025a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'Products': _CollectionConfigSimple(name='Products', description=None, generative_config=None, properties=[_Property(name='product_id', description=None, data_type=<DataType.INT: 'int'>, index_filterable=True, index_range_filters=False, index_searchable=False, nested_properties=None, tokenization=None, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='name', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='price', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.NUMBER: 'number'>, index_filterable=True, index_range_filters=False, index_searchable=False, nested_properties=None, tokenization=None, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='category', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='subcategory', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='description', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)})], references=[], reranker_config=None, vectorizer_config=None, vectorizer=None, vector_config={'default': _NamedVectorConfig(vectorizer=_NamedVectorizerConfig(vectorizer=<Vectorizers.TEXT2VEC_OLLAMA: 'text2vec-ollama'>, model={'apiEndpoint': 'http://ollama:11434', 'model': 'nomic-embed-text', 'vectorizeClassName': True}, source_properties=None), vector_index_config=_VectorIndexConfigHNSW(multi_vector=None, quantizer=None, cleanup_interval_seconds=300, distance_metric=<VectorDistances.COSINE: 'cosine'>, dynamic_ef_min=100, dynamic_ef_max=500, dynamic_ef_factor=8, ef=-1, ef_construction=128, filter_strategy=<VectorFilterStrategy.ACORN: 'acorn'>, flat_search_cutoff=40000, max_connections=32, skip=False, vector_cache_max_objects=1000000000000))})}\n"
-     ]
-    }
-   ],
-   "source": [
-    "with WeaviateConnectionManager(client=client) as weaviate_client:\n",
-    "    print(weaviate_client.collections.list_all())\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "5c6de593",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Products': _CollectionConfigSimple(name='Products', description=None, generative_config=None, properties=[_Property(name='product_id', description=None, data_type=<DataType.INT: 'int'>, index_filterable=True, index_range_filters=False, index_searchable=False, nested_properties=None, tokenization=None, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='name', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='price', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.NUMBER: 'number'>, index_filterable=True, index_range_filters=False, index_searchable=False, nested_properties=None, tokenization=None, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='category', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='subcategory', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)}), _Property(name='description', description=\"This property was generated by Weaviate's auto-schema feature on Tue Nov 25 09:37:17 2025\", data_type=<DataType.TEXT: 'text'>, index_filterable=True, index_range_filters=False, index_searchable=True, nested_properties=None, tokenization=<Tokenization.WORD: 'word'>, vectorizer_config=None, vectorizer=None, vectorizer_configs={'text2vec-ollama': _PropertyVectorizerConfig(skip=False, vectorize_property_name=False)})], references=[], reranker_config=None, vectorizer_config=None, vectorizer=None, vector_config={'default': _NamedVectorConfig(vectorizer=_NamedVectorizerConfig(vectorizer=<Vectorizers.TEXT2VEC_OLLAMA: 'text2vec-ollama'>, model={'apiEndpoint': 'http://ollama:11434', 'model': 'nomic-embed-text', 'vectorizeClassName': True}, source_properties=None), vector_index_config=_VectorIndexConfigHNSW(multi_vector=None, quantizer=None, cleanup_interval_seconds=300, distance_metric=<VectorDistances.COSINE: 'cosine'>, dynamic_ef_min=100, dynamic_ef_max=500, dynamic_ef_factor=8, ef=-1, ef_construction=128, filter_strategy=<VectorFilterStrategy.ACORN: 'acorn'>, flat_search_cutoff=40000, max_connections=32, skip=False, vector_cache_max_objects=1000000000000))})}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client.collections.list_all()"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv-chatbot",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Summary

This PR fixes the chatbot service so it can successfully talk to the ecom backend API and OpenAI by correcting environment/configuration wiring. It also adds a small notebook tweak to quickly verify product retrieval from the Weaviate vector store.

## Changes

- **Chatbot service fix**
  - Fix broken chatbot service to now use `EcomAPIClient` instead of `user_id`
  - Derive OpenAI configuration from `.env` instead of hard‑coding values, so the chatbot uses the correct API key/model in all environments.
  - Point the ecom API client to the host machine URL (rather than localhost mapping), so the chatbot can actually reach the ecom backend service when running via Docker.
  - Update chatbot service configuration to read the new values at startup.

- **Debugging / notebook support**
  - Add a basic notebook cell to check retrieved products in the Weaviate DB, making it easy to confirm that the vector store is populated and that product search returns expected results.

## Testing

- **Manual**
  - Ran the chatbot service locally (via Docker) and confirmed it starts without configuration errors.
  - Triggered chatbot flows that call the ecom backend and verified responses are returned successfully.
  - Executed the new notebook cell to retrieve products from Weaviate and confirmed relevant products are returned.

##

_Semi generated with Windsurf_ 🤖 