### PR TITLE
feat(chatbot): Add Langfuse tracing to chatbot

### DIFF
--- a/chatbot/pkg/chatbot/agent_definitions/customer_service.py
+++ b/chatbot/pkg/chatbot/agent_definitions/customer_service.py
@@ -1,4 +1,8 @@
-import openai
+try:
+    from langfuse.openai import openai
+except ImportError:
+    import openai
+
 from chatbot.graph.types import State
 
 class CustomerServiceAgent:

--- a/chatbot/pkg/chatbot/agent_definitions/product_search.py
+++ b/chatbot/pkg/chatbot/agent_definitions/product_search.py
@@ -4,7 +4,11 @@ from chatbot.graph.types import State
 from chatbot.product_retrieval import retrieve_products
 from chatbot.types import ProductVectorDBRecord
 from pydantic import BaseModel, Field
-import openai
+
+try:
+    from langfuse.openai import openai
+except ImportError:
+    import openai
 
 
 def get_product_list_prompt_str(products: list[ProductVectorDBRecord]) -> str:
@@ -58,13 +62,13 @@ class ProductSearchAgent:
             {'role': 'user', 'content': state.messages[-1]['content']}
         ]
         
-        response = self.openai_client.chat.compleletions.parse(
+        response = self.openai_client.chat.completions.parse(
             model=self.config['llm'],
             messages=input_messages,
             response_format=ProductRetrievalAgentResponse
         )
 
-        prod_retrieval_agent_response = response.choices[0].messages.parsed
+        prod_retrieval_agent_response = response.choices[0].message.parsed
 
 
 

--- a/chatbot/pkg/chatbot/agent_definitions/product_search.py
+++ b/chatbot/pkg/chatbot/agent_definitions/product_search.py
@@ -33,7 +33,7 @@ class ProductSearchAgent:
     alias: str = 'Product Search'
 
 
-    def __init__(self, config, openai_client: openai.OpenAI = None,  weaviate_client: WeaviateClient = None):
+    def __init__(self, config, openai_client: openai.OpenAI = None, weaviate_client: WeaviateClient = None):
         self.config = config
         self.weaviate_client = weaviate_client
         self.openai_client = openai.OpenAI() if openai_client is None else openai_client
@@ -58,13 +58,13 @@ class ProductSearchAgent:
             {'role': 'user', 'content': state.messages[-1]['content']}
         ]
         
-        response = self.openai_client.responses.parse(
+        response = self.openai_client.chat.compleletions.parse(
             model=self.config['llm'],
-            input=input_messages,
-            text_format=ProductRetrievalAgentResponse
+            messages=input_messages,
+            response_format=ProductRetrievalAgentResponse
         )
 
-        prod_retrieval_agent_response = response.output_parsed
+        prod_retrieval_agent_response = response.choices[0].messages.parsed
 
 
 

--- a/chatbot/pkg/chatbot/agent_definitions/router.py
+++ b/chatbot/pkg/chatbot/agent_definitions/router.py
@@ -28,12 +28,10 @@ class RouterAgent:
             {"role": "user", "content": f"Route based on this message: {state.messages[-1]['content']}"}
         ]
 
-        response = self.openai_client.responses.parse(
+        response = self.openai_client.chat.completions.parse(
             model=self.config["llm"],
-            input=input_messages,
-            text_format=DownstreamRoutesAgentResponse
+            messages=input_messages,
+            response_format=DownstreamRoutesAgentResponse
         )
 
-        return response.output_parsed.route
-
-        
+        return response.choices[0].message.parsed.route

--- a/chatbot/pkg/chatbot/agent_definitions/shopping_actions.py
+++ b/chatbot/pkg/chatbot/agent_definitions/shopping_actions.py
@@ -5,44 +5,6 @@ from agents import FunctionTool, function_tool
 from typing import Annotated
 from chatbot.tools.cart_actions import Cart
 
-# TODO: This should be moved somewhere else (This is NOT shopping actions specific functionality)
-# class Cart:
-#     def __init__(self, user_id: str):
-#         self.user_id = user_id
-#         self.items = Counter()
-
-#     def add_item(self, item_id: str, quantity: int):
-#         self.items[item_id] += quantity
-#         return self
-
-#     def remove_item(self, item_id: str, quantity: int):
-#         cur_qty = self.items.get(item_id, 0)
-#         if cur_qty < quantity:
-#             raise ValueError("Not enough quantity in cart")
-#         if cur_qty == quantity:
-#             return self.empty_item(item_id)
-    
-#         self.items[item_id] -= quantity
-#         return self
-
-#     def empty_cart(self):
-#         self.items.clear()
-#         return self
-
-#     def empty_item(self, item_id: str):
-#         cur_qty = self.items.get(item_id, 0)
-#         if cur_qty == 0:
-#             raise ValueError("Item not found in cart")
-            
-#         self.items.pop(item_id)
-#         return self
-
-#     def view_cart(self):
-#         return dict(self.items)
-
-#     def __repr__(self) -> str:
-#         return f'Cart({self.view_cart()})'
-
 
 class ShoppingActionsAgent:
 

--- a/chatbot/pkg/chatbot/chat.py
+++ b/chatbot/pkg/chatbot/chat.py
@@ -1,4 +1,8 @@
-import openai
+try:
+    from langfuse.openai import openai
+except ImportError:
+    import openai
+
 from weaviate import WeaviateClient
 from chatbot.graph.types import State
 from chatbot.agent_definitions import RouterAgent, ShoppingActionsAgent, CustomerServiceAgent, ProductSearchAgent

--- a/chatbot/pkg/chatbot/chat.py
+++ b/chatbot/pkg/chatbot/chat.py
@@ -9,6 +9,8 @@ from langgraph.checkpoint.memory import InMemorySaver
 from chatbot.graph.graph import build_graph
 from langchain_core.runnables import RunnableConfig
 import gradio as gr
+from langfuse import Langfuse
+from langfuse.langchain import CallbackHandler as LangfuseCallbackHandler
 
 
 
@@ -20,12 +22,14 @@ class Chat:
         ecom_api_client: EcomAPIClient = None,
         openai_client: openai.OpenAI = None,
         weaviate_client: WeaviateClient = None,
+        langfuse_client: Langfuse = None,
     ):
         self.config = config
         self.ecom_api_client = ecom_api_client if ecom_api_client is not None else EcomAPIClient(base_url="http://localhost:8000/api/v1")
         self.openai_client = openai.OpenAI() if openai_client is None else openai_client
         self.weaviate_client = weaviate_client
-        
+        self.langfuse_client = langfuse_client
+
         self.cart = self._fetch_cart()
         self.agents = self._initialize_agents(cart=self.cart)
         self.memory = self._initialize_memory()
@@ -38,7 +42,16 @@ class Chat:
 
     @property
     def run_config(self) -> RunnableConfig:
-        return {"configurable": {"thread_id": self.thread_id}}
+        base_conf = {
+            "configurable": {"thread_id": self.thread_id},
+        }
+
+        if self.langfuse_client is not None:
+            # TODO: Does this cause additional network I/O? 
+            # Or can LangfuseCallbackHandler gracefully fail if Langfuse is not available?
+            if self.langfuse_client.auth_check():
+                base_conf["callbacks"] = [LangfuseCallbackHandler()]
+        return base_conf
 
 
     async def query(self, query: str) -> str:

--- a/chatbot/pkg/chatbot/graph/__init__.py
+++ b/chatbot/pkg/chatbot/graph/__init__.py
@@ -1,6 +1,0 @@
-from chatbot.graph.graph import build_graph, State
-
-__all__ = [
-    "build_graph",
-    "State"
-]

--- a/chatbot/pkg/chatbot/graph/graph.py
+++ b/chatbot/pkg/chatbot/graph/graph.py
@@ -15,6 +15,7 @@ def build_graph(
         
     graph_builder = StateGraph(State)
 
+    # BUG: Conditional node doesn't show up in langfuse
     graph_builder.add_conditional_edges(START, router_agent.run)
 
     graph_builder.add_node("shopping_actions", shopping_actions_agent.run)

--- a/chatbot/pkg/chatbot/observability/utils.py
+++ b/chatbot/pkg/chatbot/observability/utils.py
@@ -1,0 +1,42 @@
+
+import base64
+from langfuse import Langfuse
+from langfuse import get_client as get_langfuse_client
+import os
+import logging
+import logfire
+
+
+def configure_langfuse() -> Langfuse:
+    # from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+    
+    LANGFUSE_AUTH = base64.b64encode(
+        f"{os.environ.get('LANGFUSE_PUBLIC_KEY')}:{os.environ.get('LANGFUSE_SECRET_KEY')}".encode()
+    ).decode()
+ 
+    # Configure OpenTelemetry endpoint & headers
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.environ.get("LANGFUSE_BASE_URL") + "/api/public/otel"
+    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+
+    langfuse = get_langfuse_client()
+
+    # BUG: logging doesn't show up
+    if langfuse.auth_check():
+        logging.info("Langfuse authentication successful")
+    else:
+        logging.warning("Langfuse authentication failed")
+
+    
+    # TODO: Should this be done only when langfuse authentication is successful?
+    # Configure logfire instrumentation.
+    logfire.configure(
+        service_name='my_agent_service',
+        send_to_logfire=False,
+    )
+    # This method automatically patches the OpenAI Agents SDK to send logs via OTLP to Langfuse.
+    logfire.instrument_openai_agents()
+    
+    # NOTE: Disabled because logfire instrumentation method for openai agents is better somehow (more fields visible in langfuse UI).
+    # OpenAIAgentsInstrumentor().instrument()
+
+    return langfuse

--- a/chatbot/pkg/pyproject.toml
+++ b/chatbot/pkg/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
     "openai-agents", "openai", 
     "langchain", "langchain_community",
     "weaviate-client",
-    "gradio"
+    "gradio",
+    "langfuse",
+    "openinference-instrumentation-openai-agents",
+    "logfire"
 ]
 
 [tool.setuptools.packages.find]

--- a/chatbot/service/app.py
+++ b/chatbot/service/app.py
@@ -9,7 +9,7 @@ import os
 
 from chatbot.external.ecom_api_client.client import EcomAPIClient
 from chatbot.external.ecom_api_client.credentials import Credentials as EcomAPICredentials
-
+from chatbot.observability.utils import configure_langfuse
 
 VERSION = "0.1.0"
 
@@ -61,10 +61,13 @@ def initialize_chat(user_id: str, thread_id: str):
         )
     )
 
+    langfuse_client = configure_langfuse()
+
     CHATS[chat_id] = Chat(
         config=CONFIG,
         weaviate_client=weaviate_client,
-        ecom_api_client=ecom_api_client
+        ecom_api_client=ecom_api_client,
+        langfuse_client=langfuse_client
     )
     CHATS[chat_id].set_thread(thread_id)
 

--- a/platform/app/docker-compose.yml
+++ b/platform/app/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       WEAVIATE_GRPC_HOST: weaviate
       WEAVIATE_GRPC_PORT: ${WEAVIATE_GRPC_PORT}
       WEAVIATE_GRPC_SECURE: false
+      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
+      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
+      LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL}
 
       # Accessing the ECOM API running on host machine from the chatbot container
       ECOM_API_BASE_URL: 'http://ecom-backend:${ECOM_API_PORT}/api/v1'


### PR DESCRIPTION
🤖 PR description partially generated with windsurf! (I still write majority of the code myself)

## Summary

- **Enable Langfuse tracing** across chatbot agents and LangGraph flows.  
- **Migrate OpenAI calls** from `responses.parse` to `chat.completions.parse`.  
- **Expose Langfuse as an external service**, configured via environment variables instead of the internal Docker network.

## Changes

- **Langfuse integration**
  - Added Langfuse dependencies to the chatbot package.
  - Implemented a `configure_langfuse` utility to create and configure a Langfuse client.
  - Updated the chatbot service to instantiate `Chat` with a Langfuse client.
  - Added Langfuse callbacks to the LangGraph graph for tracing conversational flows.
  - Configured Langfuse as an external service, wired through environment variables.
  - Conditionally import `openai` from `langfuse` when the library is installed.

- **OpenAI API usage**
  - Switched agents from `responses.parse` to `chat.completions.parse`.
  - Updated the router and product search agents to use the new `chat.completions.parse` API.
  - Fixed a minor typo in the product search agent.

- **Chatbot / agent cleanup**
  - Fixed a circular import between the chatbot graph and agent definition modules.
  - Removed a redundant `Cart` implementation from the shopping actions agent.
  - Added env vars for Langfuse connectivity in the chatbot service configuration.

## Implementation Details

- **Langfuse as an external dependency**
  - Langfuse host and credentials are injected via environment variables.
  - Docker configuration treats Langfuse as an external service instead of adding it to the internal Docker network.

- **Current tracing coverage**
  - Traces are emitted at the LangGraph and agent level for chatbot flows.
  - This provides visibility into high‑level conversation paths in Langfuse.

## Future Work (Not in This PR)

- **Weaviate product retrieval tracing**
  - Add Langfuse spans around Weaviate product retrieval calls.

- **Product retrieval response tracing**
  - Add spans for hardcoded messages in product retrieval responses for better observability.

## Known Issues / Limitations

- **LangGraph conditional node rendering**
  - Conditional nodes do not render correctly in the Langfuse UI.
  - This appears to be an upstream/external library issue and is not addressed here.

- **Router system prompt placeholder**
  - The router agent’s system prompt still contains an unreplaced placeholder.
  - Intentionally left for a follow‑up issue.
  - Potential improvement: automated checks/tests to fail when unresolved placeholders exist in system prompts.
