### PR TITLE
fix: unresolved placeholder in RouterAgent

### DIFF
--- a/chatbot/conf/config.yml
+++ b/chatbot/conf/config.yml
@@ -3,7 +3,7 @@ agents:
     downstream_routes:
       - name: product_search
         description: Helps the user find products in the catalog based on the product name or description.
-        examples: |
+        examples:
           - I am looking for headphones under 2000 rupees.
           - Do you have wind cheaters in red and white colour?
           - I want to buy a new laptop.
@@ -21,7 +21,7 @@ agents:
         
       - name: customer_service
         description: Helps the user with any customer service related queries or any general chit chat.
-        examples: |
+        examples:
           - Hello!
           - I have a complaint regarding a recent product I ordered.
           - Can you tell me the terms and conditions for the return process?
@@ -30,10 +30,9 @@ agents:
     prompts:
       system_prompt: |
         You are a helpful ecom shopping assistant tasked with redirecting the user to the appropriate specialized downstream routes. 
-        The available specialized agents are:
         {downstream_routes_desc}
         
-        Please output the appropriate route based on the user's query.
+        Please respond ONLY with the name of the appropriate downstream route based on the user's query.
     
     llm: gpt-4o-mini
 

--- a/chatbot/pkg/chatbot/agent_definitions/router.py
+++ b/chatbot/pkg/chatbot/agent_definitions/router.py
@@ -15,15 +15,41 @@ class RouterAgent:
         self.config = config
         self.openai_client = openai.OpenAI() if openai_client is None else openai_client
 
+        self.system_prompt = self._get_system_prompt()
+
     @staticmethod
     def _validate_config(config):
         downstream_routes_in_config = [d["name"] for d in config['downstream_routes']]
         assert set(downstream_routes_in_config) == set(module_config.DOWNSTREAM_ROUTES), "Downstream routes in package config do not match downstream routes in the passed config"
 
 
+    @staticmethod
+    def _get_downstream_routes_description_for_prompt(downstream_routes):
+        routes_lst = [d['name'] for d in downstream_routes]
+        desc = f"The available downstream routes are: {routes_lst}"
+        desc += "\n\n"
+
+        for idx, route in enumerate(downstream_routes):
+            desc += f"\n(Route {idx+1}) `{route['name']}`: {route['description']}"
+            desc += "\nExamples:"
+            for idx, example in enumerate(route['examples']):
+                desc += f"\n{idx+1}: {example}"
+
+            desc += "\n\n"
+        
+        desc += '\n\n'
+        return desc
+
+    def _get_system_prompt(self):
+
+        downstream_routes_desc = self._get_downstream_routes_description_for_prompt(self.config['downstream_routes'])
+        system_prompt = self.config['prompts']['system_prompt'].format(downstream_routes_desc=downstream_routes_desc)
+        return system_prompt
+
+
     def run(self, state: State) -> Literal[*module_config.DOWNSTREAM_ROUTES]:
         input_messages = [
-            {"role": "system", "content": self.config['prompts']['system_prompt']},
+            {"role": "system", "content": self.system_prompt},
             *state.messages[:-1],
             {"role": "user", "content": f"Route based on this message: {state.messages[-1]['content']}"}
         ]


### PR DESCRIPTION
# Summary

Fix unresolved placeholder in `RouterAgent`

Before:

<img width="1528" height="537" alt="image" src="https://github.com/user-attachments/assets/60be3423-d4ed-4b55-8b4b-099fda6862ea" />

After:

<img width="1524" height="695" alt="image" src="https://github.com/user-attachments/assets/1c6e56e5-2176-4142-8873-86c4ddc1597b" />


Not sure of the best practice for the following:

1. Should I re-mention output categories even though I also provide it "formally" through the constructs in the api.
2. Should I put details on how to parse in the prompt or in the Pydantic object?
3. What's the tradeoff of how much info to put in prompt vs the Pydantic object?

Cons of putting extra stuff in the prompt?  More Tokenzzz

Probably, openai stuffs the info into the context anyway - I might be duplicating info. 