### PR TITLE
Add better linting, formattiing rules + run checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,18 +54,20 @@ ingest-products-vectordb:
 	--sqlite-db-path "ecom-backend/ecom_backend.db"
 
 
+PRECOMMIT_FILES = $(if $(FILE),--files $(FILE),--all-files)
+
 check-all:
-	pre-commit run --all-files $(if $(FILE),$(FILE),)
+	pre-commit run $(PRECOMMIT_FILES)
 
 check-lint:
-	pre-commit run ruff --all-files $(if $(FILE),$(FILE),)
+	pre-commit run ruff $(PRECOMMIT_FILES)
 
 check-format:
-	pre-commit run ruff-format --all-files $(if $(FILE),$(FILE),)
+	pre-commit run ruff-format $(PRECOMMIT_FILES)
 
 # Individual make target for each pre-commit hook
 check-hook-%:
-	pre-commit run --hook-stage manual $* $(if $(FILE),$(FILE),--all-files)
+	pre-commit run --hook-stage manual $* $(PRECOMMIT_FILES)
 
 # TODO: Refine draw repo tree target
 draw-repo-tree:

--- a/Makefile
+++ b/Makefile
@@ -54,20 +54,35 @@ ingest-products-vectordb:
 	--sqlite-db-path "ecom-backend/ecom_backend.db"
 
 
-PRECOMMIT_FILES = $(if $(FILE),--files $(FILE),--all-files)
-
+# Pre-commit targets with conditional FILE handling
 check-all:
-	pre-commit run $(PRECOMMIT_FILES)
+	@if [ -n "$(FILE)" ]; then \
+		git ls-files -- $(FILE) | xargs pre-commit run --files; \
+	else \
+		pre-commit run --all-files; \
+	fi
 
 check-lint:
-	pre-commit run ruff $(PRECOMMIT_FILES)
+	@if [ -n "$(FILE)" ]; then \
+		git ls-files -- $(FILE) | xargs pre-commit run ruff --files; \
+	else \
+		pre-commit run ruff --all-files; \
+	fi
 
 check-format:
-	pre-commit run ruff-format $(PRECOMMIT_FILES)
+	@if [ -n "$(FILE)" ]; then \
+		git ls-files -- $(FILE) | xargs pre-commit run ruff-format --files; \
+	else \
+		pre-commit run ruff-format --all-files; \
+	fi
 
 # Individual make target for each pre-commit hook
 check-hook-%:
-	pre-commit run --hook-stage manual $* $(PRECOMMIT_FILES)
+	@if [ -n "$(FILE)" ]; then \
+		git ls-files -- $(FILE) | xargs pre-commit run --hook-stage manual $* --files; \
+	else \
+		pre-commit run --hook-stage manual $* --all-files; \
+	fi
 
 # TODO: Refine draw repo tree target
 draw-repo-tree:

--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/__init__.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/__init__.py
@@ -1,7 +1,7 @@
-from shopping_assistant.agent_definitions.router import RouterAgent
-from shopping_assistant.agent_definitions.shopping_actions import ShoppingActionsAgent
 from shopping_assistant.agent_definitions.customer_service import CustomerServiceAgent
 from shopping_assistant.agent_definitions.product_search import ProductSearchAgent
+from shopping_assistant.agent_definitions.router import RouterAgent
+from shopping_assistant.agent_definitions.shopping_actions import ShoppingActionsAgent
 
 __all__ = [
     "RouterAgent",

--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/customer_service.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/customer_service.py
@@ -25,9 +25,10 @@ class CustomerServiceAgent:
             model=self.config["llm"], messages=input_messages
         )
 
+        agent_response = responses_obj.choices[0].message.content
         response = {
             "role": "assistant",
-            "content": f"{self.alias} Agent: {responses_obj.choices[0].message.content}",
+            "content": f"{self.alias} Agent: {agent_response}",
         }
 
         new_state = State(

--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/product_search.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/product_search.py
@@ -1,9 +1,11 @@
-from langfuse import Langfuse, observe as langfuse_observe
+from langfuse import Langfuse
+from langfuse import observe as langfuse_observe
+from pydantic import BaseModel, Field
 from weaviate import WeaviateClient
+
 from shopping_assistant.graph.types import State
 from shopping_assistant.product_retrieval import retrieve_products
 from shopping_assistant.types import ProductVectorDBRecord
-from pydantic import BaseModel, Field
 
 try:
     from langfuse.openai import openai
@@ -29,13 +31,22 @@ class ProductParsedDetails(BaseModel):
 
 class ProductRetrievalAgentResponse(BaseModel):
     product_details: ProductParsedDetails | None = Field(
-        description="The parsed details of the product. Populate ONLY if no clarification response is needed."
+        description=(
+            "The parsed details of the product. "
+            "Populate ONLY if no clarification response is needed."
+        )
     )
     product_retrieval_query: str | None = Field(
-        description="User query rephrased as a specific retrieval query for the product. Populate ONLY if no clarification response is needed."
+        description=(
+            "User query rephrased as a specific retrieval query for the product. "
+            "Populate ONLY if no clarification response is needed."
+        )
     )
     product_clarification_response: str | None = Field(
-        description="The clarification response for the user's query when no product details were parsed."
+        description=(
+            "The clarification response for the user's query when "
+            "no product details were parsed."
+        )
     )
 
 
@@ -61,7 +72,10 @@ class ProductSearchAgent:
         products_retrieved: list[ProductVectorDBRecord],
     ) -> str:
         if not products_retrieved:
-            asst_response = "I found no products based on your query. Can you please rephrase your query?"
+            asst_response = (
+                "I found no products based on your query. "
+                "Can you please rephrase your query?"
+            )
         else:
             product_list_prompt_str = get_product_list_prompt_str(products_retrieved)
 
@@ -102,13 +116,12 @@ class ProductSearchAgent:
         prod_retrieval_agent_response = response.choices[0].message.parsed
 
         if prod_retrieval_agent_response.product_clarification_response:
+            asst_message = {
+                "role": "assistant",
+                "content": prod_retrieval_agent_response.product_clarification_response,
+            }
             new_state = State(
-                messages=[
-                    {
-                        "role": "assistant",
-                        "content": prod_retrieval_agent_response.product_clarification_response,
-                    }
-                ],
+                messages=[asst_message],
                 prev_recommended_products=state.prev_recommended_products,
             )
 

--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/router.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/router.py
@@ -1,7 +1,9 @@
 from typing import Literal
-from pydantic import BaseModel
-import shopping_assistant.config as module_config
+
 import openai
+from pydantic import BaseModel
+
+import shopping_assistant.config as module_config
 from shopping_assistant.graph.types import State
 
 
@@ -20,11 +22,15 @@ class RouterAgent:
     @staticmethod
     def _validate_config(config):
         downstream_routes_in_config = [d["name"] for d in config["downstream_routes"]]
-        assert set(downstream_routes_in_config) == set(
-            module_config.DOWNSTREAM_ROUTES
-        ), (
-            "Downstream routes in package config do not match downstream routes in the passed config"
+
+        expected_routes = set(module_config.DOWNSTREAM_ROUTES)
+        actual_routes = set(downstream_routes_in_config)
+        err_msg = (
+            "Downstream routes in package config do not match "
+            "the downstream routes in the passed config"
         )
+
+        assert actual_routes == expected_routes, err_msg
 
     @staticmethod
     def _get_downstream_routes_description_for_prompt(downstream_routes):
@@ -35,8 +41,8 @@ class RouterAgent:
         for idx, route in enumerate(downstream_routes):
             desc += f"\n(Route {idx + 1}) `{route['name']}`: {route['description']}"
             desc += "\nExamples:"
-            for idx, example in enumerate(route["examples"]):
-                desc += f"\n{idx + 1}: {example}"
+            for ex_idx, example in enumerate(route["examples"]):
+                desc += f"\n{ex_idx + 1}: {example}"
 
             desc += "\n\n"
 
@@ -53,13 +59,14 @@ class RouterAgent:
         return system_prompt
 
     def run(self, state: State) -> Literal[*module_config.DOWNSTREAM_ROUTES]:
+        route_final_instr_msg = {
+            "role": "user",
+            "content": f"Route based on this message: {state.messages[-1]['content']}",
+        }
         input_messages = [
             {"role": "system", "content": self.system_prompt},
             *state.messages[:-1],
-            {
-                "role": "user",
-                "content": f"Route based on this message: {state.messages[-1]['content']}",
-            },
+            route_final_instr_msg,
         ]
 
         response = self.openai_client.chat.completions.parse(

--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/shopping_actions.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/shopping_actions.py
@@ -1,8 +1,9 @@
 # from collections import Counter
-from shopping_assistant.graph.types import State
-from agents import Agent, Runner
-from agents import FunctionTool, function_tool
 from typing import Annotated
+
+from agents import Agent, FunctionTool, Runner, function_tool
+
+from shopping_assistant.graph.types import State
 from shopping_assistant.tools.cart_actions import Cart
 
 
@@ -33,7 +34,7 @@ class ShoppingActionsAgent:
     @property
     def tools(self):
         tools = []
-        for action, tool_lst in self.tool_store.items():
+        for _action, tool_lst in self.tool_store.items():
             tools += tool_lst
 
         return tools
@@ -111,7 +112,7 @@ class ShoppingActionsAgent:
         self, action_summary: dict[str, str], agent_actions: dict
     ) -> dict[str, str]:
         action_detailed = ""
-        for idx, (action_type, info) in enumerate(agent_actions.items()):
+        for _idx, (action_type, info) in enumerate(agent_actions.items()):
             action_detailed += action_summary[action_type] + "\n"
             for tool in info["tools"]:
                 action_detailed += f"- Tool=`{tool.name}`: {tool.description}" + "\n"

--- a/packages/shopping-assistant/src/shopping_assistant/chat.py
+++ b/packages/shopping-assistant/src/shopping_assistant/chat.py
@@ -3,25 +3,26 @@ try:
 except ImportError:
     import openai
 
+import gradio as gr
+from langchain_core.runnables import RunnableConfig
+from langfuse import Langfuse
+from langfuse.langchain import CallbackHandler as LangfuseCallbackHandler
+from langgraph.checkpoint.memory import InMemorySaver
 from weaviate import WeaviateClient
-from shopping_assistant.graph.types import State
+
 from shopping_assistant.agent_definitions import (
-    RouterAgent,
-    ShoppingActionsAgent,
     CustomerServiceAgent,
     ProductSearchAgent,
+    RouterAgent,
+    ShoppingActionsAgent,
 )
-from shopping_assistant.tools.cart_actions import Cart
 from shopping_assistant.external.ecom_api_client.client import EcomAPIClient
 from shopping_assistant.external.ecom_api_client.credentials import (
     Credentials as EcomAPICredentials,
 )
-from langgraph.checkpoint.memory import InMemorySaver
 from shopping_assistant.graph.graph import build_graph
-from langchain_core.runnables import RunnableConfig
-import gradio as gr
-from langfuse import Langfuse
-from langfuse.langchain import CallbackHandler as LangfuseCallbackHandler
+from shopping_assistant.graph.types import State
+from shopping_assistant.tools.cart_actions import Cart
 
 
 class Chat:
@@ -58,9 +59,9 @@ class Chat:
             "configurable": {"thread_id": self.thread_id},
         }
 
-        if self.langfuse_client is not None:
-            # TODO: Does this cause additional network I/O?
-            # Or can LangfuseCallbackHandler gracefully fail if Langfuse is not available?
+        if self.langfuse_client is not None:  # noqa: SIM102
+            # TODO: Does this cause additional network I/O? Or can
+            # LangfuseCallbackHandler gracefully fail if Langfuse is not available?
             if self.langfuse_client.auth_check():
                 base_conf["callbacks"] = [LangfuseCallbackHandler()]
         return base_conf
@@ -86,7 +87,7 @@ class Chat:
             print(new_state["messages"][-1]["content"])
 
     def web_ui_chat(self):
-        async def chat(user_input: str, history):
+        async def chat(user_input: str, history):  # noqa: ARG001
             message = {"role": "user", "content": user_input}
 
             response = await self.graph.ainvoke(
@@ -139,9 +140,11 @@ class Chat:
 
 if __name__ == "__main__":
     import asyncio
+
+    from agents import set_tracing_disabled
+
     from shopping_assistant.config import load_config
     from shopping_assistant.env import load_env
-    from agents import set_tracing_disabled
 
     set_tracing_disabled(True)
     load_env(

--- a/packages/shopping-assistant/src/shopping_assistant/config.py
+++ b/packages/shopping-assistant/src/shopping_assistant/config.py
@@ -1,12 +1,14 @@
-from shopping_assistant.constants import PROJECT_ROOT
-import yaml
 from pathlib import Path
+
+import yaml
+
+from shopping_assistant.constants import PROJECT_ROOT
 
 # TODO:
 # Make a distinction between installation package and framework
 # The config path specification should be part of the project / folder structure
-# created with the framework capabilities of the package but NOT part of the package itself
-# So something like chatbot create project <project_name> <project_dir> <args>
+# created with the framework capabilities of the package but NOT part of the package
+# itself. So something like chatbot create project <project_name> <project_dir> <args>
 CONFIG_FILE_PATH = Path(PROJECT_ROOT) / "conf/config.yml"
 
 DOWNSTREAM_ROUTES = ["product_search", "shopping_actions", "customer_service"]
@@ -14,7 +16,7 @@ DOWNSTREAM_ROUTES = ["product_search", "shopping_actions", "customer_service"]
 
 def load_config(fpath: str = CONFIG_FILE_PATH):
     fpath = Path(fpath).expanduser()
-    with open(fpath, "r") as f:
+    with open(fpath) as f:
         conf = yaml.safe_load(f)
 
     return conf

--- a/packages/shopping-assistant/src/shopping_assistant/env.py
+++ b/packages/shopping-assistant/src/shopping_assistant/env.py
@@ -1,5 +1,7 @@
-from dotenv import load_dotenv
 from pathlib import Path
+
+from dotenv import load_dotenv
+
 from shopping_assistant.constants import PROJECT_ROOT
 
 ENV_VARS_FILE_PATH = Path(PROJECT_ROOT) / ".env"

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/client.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/client.py
@@ -1,8 +1,8 @@
+from shopping_assistant.external.ecom_api_client.credentials import Credentials
 from shopping_assistant.external.ecom_api_client.resources.carts import CartsAPIClient
 from shopping_assistant.external.ecom_api_client.resources.products import (
     ProductsAPIClient,
 )
-from shopping_assistant.external.ecom_api_client.credentials import Credentials
 
 
 class EcomAPIClient:

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/http.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/http.py
@@ -1,10 +1,11 @@
+import pydantic
 import requests
+
 from shopping_assistant.external.ecom_api_client.credentials import Credentials
 from shopping_assistant.external.ecom_api_client.exceptions import (
     ApiError,
     ExceptionResponse,
 )
-import pydantic
 
 
 class HttpClient:
@@ -31,8 +32,9 @@ class HttpClient:
 
         response_json = response_obj.json()
 
-        if isinstance(response_json, dict):
-            # TODO: Temp way of differentiating between routes not found and other resource not found errors (since both have 404 status code)
+        if isinstance(response_json, dict):  # noqa: SIM102
+            # TODO: Temp way of differentiating between routes not found and
+            # other resource not found errors (since both have 404 status code)
             # TODO: Must standardize API response from server side
             if response_json.get("error_code", "") == "NOT_FOUND":
                 raise ApiError(
@@ -42,7 +44,8 @@ class HttpClient:
                 )
 
         try:
-            # Check if response is an API error (TODO: Must standardize API response from server side)
+            # Check if response is an API error
+            # (TODO: Must standardize API response from server side)
             response = ExceptionResponse.model_validate(response_json)
             if raise_error:
                 raise ApiError(response)

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/client.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/client.py
@@ -1,13 +1,13 @@
-from shopping_assistant.external.ecom_api_client.http import HttpClient
 from shopping_assistant.external.ecom_api_client.credentials import Credentials
+from shopping_assistant.external.ecom_api_client.exceptions import (
+    ApiError,
+    ExceptionResponse,
+)
+from shopping_assistant.external.ecom_api_client.http import HttpClient
 from shopping_assistant.external.ecom_api_client.resources.carts.types import (
     CartCreateBody,
     CartResponse,
     CartUpdateBody,
-)
-from shopping_assistant.external.ecom_api_client.exceptions import (
-    ApiError,
-    ExceptionResponse,
 )
 
 

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/types.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
 from datetime import datetime
+
+from pydantic import BaseModel
 
 
 class CartItemCreate(BaseModel):

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/products/client.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/products/client.py
@@ -1,11 +1,11 @@
-from shopping_assistant.external.ecom_api_client.http import HttpClient
 from shopping_assistant.external.ecom_api_client.credentials import Credentials
-from shopping_assistant.external.ecom_api_client.resources.products.types import (
-    ProductResponse,
-)
 from shopping_assistant.external.ecom_api_client.exceptions import (
     ApiError,
     ExceptionResponse,
+)
+from shopping_assistant.external.ecom_api_client.http import HttpClient
+from shopping_assistant.external.ecom_api_client.resources.products.types import (
+    ProductResponse,
 )
 
 

--- a/packages/shopping-assistant/src/shopping_assistant/graph/graph.py
+++ b/packages/shopping-assistant/src/shopping_assistant/graph/graph.py
@@ -1,13 +1,14 @@
+import langgraph.typing as lg_ty
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
 from shopping_assistant.agent_definitions import (
-    RouterAgent,
-    ShoppingActionsAgent,
     CustomerServiceAgent,
     ProductSearchAgent,
+    RouterAgent,
+    ShoppingActionsAgent,
 )
-from langgraph.graph import StateGraph, START, END
-from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.graph.state import CompiledStateGraph
-import langgraph.typing as lg_ty
 from shopping_assistant.graph.types import State
 
 
@@ -16,7 +17,7 @@ def build_graph(
     shopping_actions_agent: ShoppingActionsAgent,
     customer_service_agent: CustomerServiceAgent,
     product_search_agent: ProductSearchAgent,
-    memory: InMemorySaver = InMemorySaver(),
+    memory: InMemorySaver = InMemorySaver(),  # noqa: B008
 ) -> CompiledStateGraph[lg_ty.StateT, lg_ty.ContextT, lg_ty.InputT, lg_ty.OutputT]:
     graph_builder = StateGraph(State)
 

--- a/packages/shopping-assistant/src/shopping_assistant/graph/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/graph/types.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, Field
 from typing import Annotated
-from shopping_assistant.graph.utils import add_messages_openai
+
+from pydantic import BaseModel, Field
+
 import shopping_assistant.config as module_config
+from shopping_assistant.graph.utils import add_messages_openai
 from shopping_assistant.types import ProductVectorDBRecord
 
 

--- a/packages/shopping-assistant/src/shopping_assistant/graph/utils.py
+++ b/packages/shopping-assistant/src/shopping_assistant/graph/utils.py
@@ -1,8 +1,10 @@
+import contextlib
+
 from langchain_community.adapters.openai import (
     convert_message_to_dict as convert_lc_message_to_openai_dict,
 )
-from langgraph.graph import add_messages
 from langchain_core.messages import BaseMessage
+from langgraph.graph import add_messages
 
 
 def add_messages_openai(
@@ -12,9 +14,8 @@ def add_messages_openai(
     messages_comb = add_messages(messages_l, messages_r)
 
     for idx, msg in enumerate(messages_comb):
-        try:
+        # TODO: Consider handling better vs suppressing
+        with contextlib.suppress(TypeError):
             messages_comb[idx] = convert_lc_message_to_openai_dict(msg)
-        except TypeError:
-            pass
 
     return messages_comb

--- a/packages/shopping-assistant/src/shopping_assistant/observability/utils.py
+++ b/packages/shopping-assistant/src/shopping_assistant/observability/utils.py
@@ -1,23 +1,27 @@
 import base64
+import logging
+import os
+
+import logfire
 from langfuse import Langfuse
 from langfuse import get_client as get_langfuse_client
-import os
-import logging
-import logfire
 
 
 def configure_langfuse() -> Langfuse:
     # from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
-    LANGFUSE_AUTH = base64.b64encode(
-        f"{os.environ.get('LANGFUSE_PUBLIC_KEY')}:{os.environ.get('LANGFUSE_SECRET_KEY')}".encode()
+    langfuse_public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
+    langfuse_secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
+
+    langfuse_auth = base64.b64encode(
+        f"{langfuse_public_key}:{langfuse_secret_key}".encode()
     ).decode()
 
     # Configure OpenTelemetry endpoint & headers
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
         os.environ.get("LANGFUSE_BASE_URL") + "/api/public/otel"
     )
-    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}"
+    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {langfuse_auth}"
 
     langfuse = get_langfuse_client()
 
@@ -33,10 +37,12 @@ def configure_langfuse() -> Langfuse:
         service_name="my_agent_service",
         send_to_logfire=False,
     )
-    # This method automatically patches the OpenAI Agents SDK to send logs via OTLP to Langfuse.
+    # This method automatically patches the OpenAI Agents SDK to
+    # send logs via OTLP to Langfuse.
     logfire.instrument_openai_agents()
 
-    # NOTE: Disabled because logfire instrumentation method for openai agents is better somehow (more fields visible in langfuse UI).
+    # NOTE: Disabled because logfire instrumentation method for openai agents
+    # (more fields visible in langfuse UI).
     # OpenAIAgentsInstrumentor().instrument()
 
     return langfuse

--- a/packages/shopping-assistant/src/shopping_assistant/product_retrieval.py
+++ b/packages/shopping-assistant/src/shopping_assistant/product_retrieval.py
@@ -1,8 +1,9 @@
-from weaviate import WeaviateClient
-import weaviate.classes as wvc
 import functools
+
 import weaviate
+import weaviate.classes as wvc
 from langfuse import observe as langfuse_observe
+from weaviate import WeaviateClient
 
 
 class WeaviateConnectionManager:
@@ -38,7 +39,7 @@ def _retrieve_products_client(
 
 
 @langfuse_observe(name="retrieve-products", as_type="retriever")
-def retrieve_products(
+def retrieve_products(  # noqa: PLR0913
     query: str = None,
     categories: list[str] = None,
     subcategories: list[str] = None,
@@ -47,10 +48,7 @@ def retrieve_products(
     n: int = 5,
     weaviate_client: WeaviateClient = None,
 ):
-    """
-    Retrieve products from the catalog based on the given query and filters.
-    """
-
+    """Retrieve products from the catalog based on the given query and filters."""
     filters = []
 
     if categories:
@@ -80,9 +78,9 @@ def retrieve_products(
         filter_obj = None
 
     if weaviate_client is None:
-        with weaviate.connect_to_local() as weaviate_client:
+        with weaviate.connect_to_local() as weaviate_client_connected:
             product_retrieval_response = _retrieve_products_client(
-                weaviate_client=weaviate_client,
+                weaviate_client=weaviate_client_connected,
                 filter_obj=filter_obj,
                 query=query,
                 n=n,

--- a/ruff.toml
+++ b/ruff.toml
@@ -73,3 +73,12 @@ max-complexity = 10
 
 [lint.pydocstyle]
 convention = "google"
+
+[lint.flake8-bugbear]
+extend-immutable-calls = [
+    "fastapi.Depends",
+    "fastapi.Query",
+    "fastapi.Path",
+    "fastapi.Header",
+    "fastapi.Cookie",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,7 +31,26 @@ line-ending = "auto"
 [lint]
 
 # TODO: Add a custom list later
-# select = []
+select = [
+    "A", # builtin-variable-shadowing
+    "ARG", # flake8-unused-arguments
+    "B", # flake8-bugbear
+    "C", # flake8-comprehensions
+    "D", # pydocstyle
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "FLY", # flynt
+    "G", # flake8-logging-format
+    "I", # isort
+    "N", # pep8-naming
+    "PGH", # pygrep-hooks
+    "PL", # pylint
+    "RET", # flake8-return
+    "SIM", # flake8-simplify
+    "SLF", # flake8-self
+    "UP", # pyupgrade
+    "W", # pycodestyle warnings
+]
 # ignore = []
 
 fixable = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,7 +36,6 @@ select = [
     "ARG", # flake8-unused-arguments
     "B", # flake8-bugbear
     "C", # flake8-comprehensions
-    "D", # pydocstyle
     "E", # pycodestyle errors
     "F", # pyflakes
     "FLY", # flynt
@@ -51,7 +50,13 @@ select = [
     "UP", # pyupgrade
     "W", # pycodestyle warnings
 ]
-# ignore = []
+ignore = [
+    # TODO: Ignoring docstring issues for now
+    "D", # pydocstyle
+    "SIM108", # ternary operator
+    "RET504", # unnecessary-assignment-before-return
+
+]
 
 fixable = [
     "ALL", # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/services/ecom-backend/api/v1/exception_handlers.py
+++ b/services/ecom-backend/api/v1/exception_handlers.py
@@ -1,11 +1,12 @@
+from core.exceptions import BaseAppException
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
-from core.exceptions import BaseAppException
 
 # NOTE: Ref: https://medium.com/delivus/exception-handling-best-practices-in-python-a-fastapi-perspective-98ede2256870
 
 
-def app_exception_handler(request: Request, exc: BaseAppException):
+# TODO: ARG001 Unused function argument: `request`
+def app_exception_handler(request: Request, exc: BaseAppException):  # noqa: ARG001
     return JSONResponse(
         status_code=exc.status_code,
         content={
@@ -16,7 +17,8 @@ def app_exception_handler(request: Request, exc: BaseAppException):
     )
 
 
-def uncaught_exception_handler(request: Request, exc: Exception):
+# TODO: ARG001 Unused function argument: `request`
+def uncaught_exception_handler(request: Request, exc: Exception):  # noqa: ARG001
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={

--- a/services/ecom-backend/api/v1/router.py
+++ b/services/ecom-backend/api/v1/router.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter
 from domains.carts.api.router import router as carts_router
 from domains.products.api.router import router as products_router
 from domains.users.api.router import router as users_router
+from fastapi import APIRouter
 
 api_v1_router = APIRouter()
 api_v1_router.include_router(carts_router)

--- a/services/ecom-backend/api/v1/schemas.py
+++ b/services/ecom-backend/api/v1/schemas.py
@@ -1,17 +1,20 @@
+from typing import Generic, TypeVar
+
 from pydantic import BaseModel
-from typing import Generic, TypeVar, Optional
 
 T = TypeVar("T")
 
 
-class SuccessResponse(BaseModel, Generic[T]):
+# TODO: UP046 Generic class `SuccessResponse` uses `Generic` subclass
+# instead of type parameters
+class SuccessResponse(BaseModel, Generic[T]):  # noqa: UP046
     success: bool = True
     message: str = "OK"
-    data: Optional[T] = None
+    data: T | None = None
 
 
 class ErrorResponse(BaseModel):
     success: bool = False
     message: str
-    error_code: Optional[str] = None
-    errors: Optional[list[str]] = None
+    error_code: str | None = None
+    errors: list[str] | None = None

--- a/services/ecom-backend/app.py
+++ b/services/ecom-backend/app.py
@@ -1,7 +1,7 @@
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from api.v1.exception_handlers import register_exception_handlers
 from api.v1.router import api_v1_router
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 # Main app with no docs
 app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)

--- a/services/ecom-backend/core/database.py
+++ b/services/ecom-backend/core/database.py
@@ -1,8 +1,10 @@
+from collections.abc import Generator
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
 from core.config import settings
-from typing import Generator
 
 DATABASE_URL = f"sqlite:///{settings.db_name}.db"
 engine = create_engine(DATABASE_URL)

--- a/services/ecom-backend/core/exceptions.py
+++ b/services/ecom-backend/core/exceptions.py
@@ -1,8 +1,9 @@
 from fastapi import status
 
 
-class BaseAppException(Exception):
-    def __init__(
+# TODO: N818 Exception name `BaseAppException` should be named with an Error suffix
+class BaseAppException(Exception):  # noqa: N818
+    def _1_init__(
         self, message: str, status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
     ):
         self.message = message

--- a/services/ecom-backend/domains/__init__.py
+++ b/services/ecom-backend/domains/__init__.py
@@ -1,4 +1,4 @@
-from domains.users import models as users_models
+from domains.accounts import models as accounts_models
 from domains.carts import models as carts_models
 from domains.products import models as products_models
-from domains.accounts import models as accounts_models
+from domains.users import models as users_models

--- a/services/ecom-backend/domains/carts/api/dependencies.py
+++ b/services/ecom-backend/domains/carts/api/dependencies.py
@@ -1,7 +1,8 @@
 from core.database import get_db
 from fastapi import Depends
-from domains.carts.repository import SQLAlchemyCartRepository
 from sqlalchemy.orm import Session
+
+from domains.carts.repository import SQLAlchemyCartRepository
 from domains.carts.service import CartService
 from domains.products.repository import SQLAlchemyProductRepository
 from domains.products.service import ProductService

--- a/services/ecom-backend/domains/carts/api/router.py
+++ b/services/ecom-backend/domains/carts/api/router.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, status, Depends, Query
-from domains.carts.schemas import CartData, CartCreate, CartUpdate
-from domains.carts.service import CartService
+from fastapi import APIRouter, Depends, Query, status
+
 from domains.carts.api.dependencies import get_cart_service
+from domains.carts.schemas import CartCreate, CartData, CartUpdate
+from domains.carts.service import CartService
 from domains.users.api.dependencies import get_current_user
 from domains.users.models import UserDB
 

--- a/services/ecom-backend/domains/carts/models.py
+++ b/services/ecom-backend/domains/carts/models.py
@@ -1,8 +1,8 @@
 from core.database import Base
-from sqlalchemy import Column, Integer, Float, ForeignKey
-from sqlalchemy.sql.sqltypes import TIMESTAMP
+from sqlalchemy import Column, Float, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func as sql_func
+from sqlalchemy.sql.sqltypes import TIMESTAMP
 
 __all__ = ("CartDB", "CartItemDB")
 

--- a/services/ecom-backend/domains/carts/repository.py
+++ b/services/ecom-backend/domains/carts/repository.py
@@ -1,7 +1,9 @@
-from sqlalchemy.orm import Session
-from domains.carts.models import CartDB, CartItemDB
-from core.exceptions import ResourceNotFoundException
 from abc import ABC, abstractmethod
+
+from core.exceptions import ResourceNotFoundException
+from sqlalchemy.orm import Session
+
+from domains.carts.models import CartDB, CartItemDB
 
 
 class CartRepository(ABC):
@@ -48,7 +50,7 @@ class SQLAlchemyCartRepository(CartRepository):
             raise ResourceNotFoundException(f"Cart not found for cart_id {cart_id}")
         return cart
 
-    def create(self, cart: CartDB, user_id: int) -> CartDB:
+    def create(self, cart: CartDB) -> CartDB:
         self.db.add(cart)
         self.db.commit()
         self.db.refresh(cart)

--- a/services/ecom-backend/domains/carts/schemas.py
+++ b/services/ecom-backend/domains/carts/schemas.py
@@ -1,9 +1,11 @@
 """DTOs"""
 
-from pydantic import BaseModel
 from datetime import datetime
 
-# TODO: Keeping the service layer schemas and API layer schemas same (for now). Need to add clear separation later (Add api/schemas.py => request/response objects)
+from pydantic import BaseModel
+
+# TODO: Keeping the service layer schemas and API layer schemas same (for now).
+# Need to add clear separation later (Add api/schemas.py => request/response objects)
 
 # Input Schemas
 

--- a/services/ecom-backend/domains/carts/service.py
+++ b/services/ecom-backend/domains/carts/service.py
@@ -1,9 +1,11 @@
-from domains.carts.schemas import CartCreate, CartData, CartUpdate
-from domains.carts.repository import CartRepository
-from domains.products.service import ProductService
-from domains.carts.models import CartItemDB, CartDB
-from core.exceptions import ResourceNotFoundException
 from typing import Literal
+
+from core.exceptions import ResourceNotFoundException
+
+from domains.carts.models import CartDB, CartItemDB
+from domains.carts.repository import CartRepository
+from domains.carts.schemas import CartCreate, CartData, CartUpdate
+from domains.products.service import ProductService
 
 
 class CartService:

--- a/services/ecom-backend/domains/products/api/dependencies.py
+++ b/services/ecom-backend/domains/products/api/dependencies.py
@@ -1,8 +1,9 @@
 from core.database import get_db
 from fastapi import Depends
+from sqlalchemy.orm import Session
+
 from domains.products.repository import SQLAlchemyProductRepository
 from domains.products.service import ProductService
-from sqlalchemy.orm import Session
 
 
 def get_sqlalchemy_product_repo(

--- a/services/ecom-backend/domains/products/api/router.py
+++ b/services/ecom-backend/domains/products/api/router.py
@@ -1,13 +1,14 @@
+from core.exceptions import ValidationException
 from fastapi import APIRouter, Depends, Query
-from domains.products.service import ProductService
-from domains.products.schemas import ProductData
+
 from domains.products.api.dependencies import get_product_service
+from domains.products.schemas import ProductData
+from domains.products.service import ProductService
 from domains.products.types import (
-    ProductHierarchyFilter,
     EmptyProductHierarchyFilterError,
     MultipleProductHierarchyFilterError,
+    ProductHierarchyFilter,
 )
-from core.exceptions import ValidationException
 
 router = APIRouter(tags=["products"], prefix="/products")
 
@@ -22,7 +23,7 @@ def get_all_products(
 
 
 @router.get("/search", response_model=list[ProductData])
-def search(
+def search(  # noqa: PLR0913
     category_id: int | None = Query(None),
     subcategory_id: int | None = Query(None),
     product_id: int | None = Query(None),
@@ -46,7 +47,7 @@ def search(
     except EmptyProductHierarchyFilterError:
         hier_filter = None
     except MultipleProductHierarchyFilterError as e:
-        raise ValidationException(str(e))
+        raise ValidationException(str(e)) from e
     return service.search(page, limit, hier_filter, keywords=keywords)
 
 

--- a/services/ecom-backend/domains/products/models.py
+++ b/services/ecom-backend/domains/products/models.py
@@ -1,9 +1,15 @@
 from core.database import Base
-from sqlalchemy import Integer, Column, String, Float
-from sqlalchemy.sql.sqltypes import TIMESTAMP
-from sqlalchemy.sql.expression import text
+from sqlalchemy import (
+    Column,
+    Float,
+    ForeignKeyConstraint,
+    Integer,
+    PrimaryKeyConstraint,
+    String,
+)
 from sqlalchemy.orm import relationship
-from sqlalchemy import PrimaryKeyConstraint, ForeignKeyConstraint
+from sqlalchemy.sql.expression import text
+from sqlalchemy.sql.sqltypes import TIMESTAMP
 
 
 class ProductDB(Base):

--- a/services/ecom-backend/domains/products/repository.py
+++ b/services/ecom-backend/domains/products/repository.py
@@ -1,9 +1,11 @@
-from domains.products.models import ProductDB
-from sqlalchemy.orm import Session
 from abc import ABC, abstractmethod
-from core.exceptions import ResourceNotFoundException
+
 import sqlalchemy
+from core.exceptions import ResourceNotFoundException
 from sqlalchemy import func as sql_func
+from sqlalchemy.orm import Session
+
+from domains.products.models import ProductDB
 from domains.products.types import ProductHierarchyFilter
 
 
@@ -100,10 +102,12 @@ class SQLAlchemyProductRepository(ProductRepository):
         keyword_filters = []
         if keywords is not None:
             for keyword in keywords:
-                keyword = keyword.lower()
-                keyword_filters.append(sql_func.lower(ProductDB.name).contains(keyword))
+                keyword_lower = keyword.lower()
                 keyword_filters.append(
-                    sql_func.lower(ProductDB.description).contains(keyword)
+                    sql_func.lower(ProductDB.name).contains(keyword_lower)
+                )
+                keyword_filters.append(
+                    sql_func.lower(ProductDB.description).contains(keyword_lower)
                 )
 
         keyword_filter = sqlalchemy.or_(*keyword_filters)

--- a/services/ecom-backend/domains/products/schemas.py
+++ b/services/ecom-backend/domains/products/schemas.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel, model_validator
 
-
 # Input Schemas
 
 

--- a/services/ecom-backend/domains/products/service.py
+++ b/services/ecom-backend/domains/products/service.py
@@ -1,6 +1,6 @@
-from domains.products.repository import ProductRepository
-from domains.products.schemas import ProductData, ProductCreate, ProductUpdate
 from domains.products.models import ProductDB
+from domains.products.repository import ProductRepository
+from domains.products.schemas import ProductCreate, ProductData, ProductUpdate
 from domains.products.types import ProductHierarchyFilter
 
 

--- a/services/ecom-backend/domains/users/api/dependencies.py
+++ b/services/ecom-backend/domains/users/api/dependencies.py
@@ -1,8 +1,9 @@
 from core.database import get_db
+from core.exceptions import ResourceNotFoundException, UnauthorizedException
 from fastapi import Depends, Header
 from sqlalchemy.orm import Session
+
 from domains.users.models import UserDB
-from core.exceptions import UnauthorizedException, ResourceNotFoundException
 from domains.users.repository import SQLAlchemyUserRepository
 from domains.users.service import UserService
 

--- a/services/ecom-backend/domains/users/api/router.py
+++ b/services/ecom-backend/domains/users/api/router.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, Query
+
+from domains.users.api.dependencies import get_user_service
 from domains.users.schemas import UserData
 from domains.users.service import UserService
-from domains.users.api.dependencies import get_user_service
 
 router = APIRouter(tags=["users"], prefix="/users")
 

--- a/services/ecom-backend/domains/users/models.py
+++ b/services/ecom-backend/domains/users/models.py
@@ -1,9 +1,8 @@
 from core.database import Base
-from sqlalchemy import Column, Integer, String, Enum
-from sqlalchemy.sql.sqltypes import TIMESTAMP
-from sqlalchemy.sql.expression import text
+from sqlalchemy import Column, Enum, Integer, String
 from sqlalchemy.orm import relationship
-
+from sqlalchemy.sql.expression import text
+from sqlalchemy.sql.sqltypes import TIMESTAMP
 
 __all__ = ("UserDB",)
 

--- a/services/ecom-backend/domains/users/repository.py
+++ b/services/ecom-backend/domains/users/repository.py
@@ -1,5 +1,7 @@
-from sqlalchemy.orm import Session
 from abc import ABC, abstractmethod
+
+from sqlalchemy.orm import Session
+
 from domains.users.models import UserDB
 
 

--- a/services/ecom-backend/domains/users/schemas.py
+++ b/services/ecom-backend/domains/users/schemas.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
 from datetime import datetime
+
+from pydantic import BaseModel
 
 # Output Schemas
 

--- a/services/ecom-backend/migrations/env.py
+++ b/services/ecom-backend/migrations/env.py
@@ -1,16 +1,14 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
-from core.database import Base, DATABASE_URL
+from core.database import DATABASE_URL, Base
+from domains.accounts.models import *  # noqa: F403
+from domains.carts.models import *  # noqa: F403
+from domains.products.models import *  # noqa: F403
 
 # import all models here
 from domains.users.models import *  # noqa: F403
-from domains.products.models import *  # noqa: F403
-from domains.carts.models import *  # noqa: F403
-from domains.accounts.models import *  # noqa: F403
+from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/services/ecom-backend/migrations/versions/8a3fde54fa59_add_tables.py
+++ b/services/ecom-backend/migrations/versions/8a3fde54fa59_add_tables.py
@@ -6,17 +6,16 @@ Create Date: 2025-11-29 17:44:11.927555
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "8a3fde54fa59"
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/services/ecom-backend/migrations/versions/f9c2f0462ab9_add_slug_to_products_tables.py
+++ b/services/ecom-backend/migrations/versions/f9c2f0462ab9_add_slug_to_products_tables.py
@@ -6,17 +6,16 @@ Create Date: 2025-12-02 14:54:37.933946
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "f9c2f0462ab9"
-down_revision: Union[str, Sequence[str], None] = "8a3fde54fa59"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "8a3fde54fa59"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/services/ecom-backend/scripts/ingest_product_data.py
+++ b/services/ecom-backend/scripts/ingest_product_data.py
@@ -4,9 +4,10 @@ import argparse
 import logging
 import os
 import sys
-import pandas as pd
-from sqlalchemy import create_engine, text as sql_text
 
+import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy import text as sql_text
 
 # NOTE: Crafted by a Human, Refactored by an AI.
 # NOTE: Sometimes, not so good an idea.
@@ -114,8 +115,8 @@ def execute_sql_script(conn, sql_script):
             conn.execute(sql_text(statement))
             conn.commit()
         except Exception as e:
-            logger.error(f"Error executing SQL: {statement}")
-            logger.error(f"Error details: {str(e)}")
+            logger.error("Error executing SQL: %s", statement)
+            logger.error("Error details: %s", str(e))
             conn.rollback()
             raise
 

--- a/services/shopping-assistant/app.py
+++ b/services/shopping-assistant/app.py
@@ -1,11 +1,11 @@
+import os
+
+import weaviate
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from shopping_assistant.chat import Chat
 from shopping_assistant.config import load_config
-import weaviate
-import os
-
 from shopping_assistant.external.ecom_api_client.client import EcomAPIClient
 from shopping_assistant.external.ecom_api_client.credentials import (
     Credentials as EcomAPICredentials,
@@ -16,7 +16,10 @@ VERSION = "0.1.0"
 
 app = FastAPI(
     title="Shopping Assistant Chatbot API",
-    description="A shopping assistant chatbot that uses GenAI to help customers find products they are looking for.",
+    description=(
+        "A shopping assistant chatbot that uses GenAI to help customers "
+        "find products they are looking for."
+    ),
     version=VERSION,
 )
 

--- a/services/shopping-assistant/scripts/ingest_product_data_into_vectorstore.py
+++ b/services/shopping-assistant/scripts/ingest_product_data_into_vectorstore.py
@@ -1,12 +1,13 @@
 import argparse
 import logging
+import os
+
+import pandas as pd
+import sqlalchemy
 import weaviate
 import weaviate.classes as wvc
-import os
-import sqlalchemy
-from shopping_assistant.product_retrieval import WeaviateConnectionManager
-import pandas as pd
 from dotenv import load_dotenv
+from shopping_assistant.product_retrieval import WeaviateConnectionManager
 
 # TODO: Adhoc, change env for weaviate in the file
 load_dotenv("platform/app/.env")
@@ -117,7 +118,7 @@ with WeaviateConnectionManager(client=weaviate_client) as weaviate_client_connec
         "Ingesting %s records into collection: %s", len(df), VECTOR_DB_COLLECTION_NAME
     )
     with products.batch.fixed_size(batch_size=WEAVIATE_INGESTION_BATCH_SIZE) as batch:
-        for idx, row in df[PRODUCT_DATA_FIELDS].iterrows():
+        for _idx, row in df[PRODUCT_DATA_FIELDS].iterrows():
             rec = row.to_dict()
             batch.add_object(properties=rec)
 


### PR DESCRIPTION
# Description

1. Added the following ruff rules to be autofixed
```yaml
select = [
    "A", # builtin-variable-shadowing
    "ARG", # flake8-unused-arguments
    "B", # flake8-bugbear
    "C", # flake8-comprehensions
    "E", # pycodestyle errors
    "F", # pyflakes
    "FLY", # flynt
    "G", # flake8-logging-format
    "I", # isort
    "N", # pep8-naming
    "PGH", # pygrep-hooks
    "PL", # pylint
    "RET", # flake8-return
    "SIM", # flake8-simplify
    "SLF", # flake8-self
    "UP", # pyupgrade
    "W", # pycodestyle warnings
]
```

2. Currently ignoring all docstring issues + few others
```yaml
ignore = [
    # TODO: Ignoring docstring issues for now
    "D", # pydocstyle
    "SIM108", # ternary operator
    "RET504", # unnecessary-assignment-before-return

]
```

3. Ignore these "errors" for fastapi 

```yaml
[lint.flake8-bugbear]
extend-immutable-calls = [
    "fastapi.Depends",
    "fastapi.Query",
    "fastapi.Path",
    "fastapi.Header",
    "fastapi.Cookie",
]
```
4. Fix running pre-commit through make for specific files

```
$  make check-all FILE="services/ecom-backend"
```

5. Painfully fix all linting errors
6. Not break things

