### PR TITLE
fix(ecom-backend): add default empty cart creation when no cart was found for a user

### DIFF
--- a/services/ecom-backend/domains/carts/service.py
+++ b/services/ecom-backend/domains/carts/service.py
@@ -14,7 +14,12 @@ class CartService:
         self.product_service = product_service
 
     def get_all(self, user_id: int, page: int, limit: int) -> list[CartData]:
-        carts_db = self.repo.get_all(user_id, page, limit)
+        try:
+            carts_db = self.repo.get_all(user_id, page, limit)
+        except ResourceNotFoundException:
+            new_cart_db = self.repo.create(CartDB(user_id=user_id, amount=0))
+            carts_db = [new_cart_db]
+
         return [CartData.model_validate(cart_db) for cart_db in carts_db]
 
     def get(self, cart_id: int) -> CartData:


### PR DESCRIPTION
# Description


- Add default empty cart creation when no cart was found for a user
- Happens in service layer (should it be in API layer?)
- Should the api response reflect if no cart was found but a new one was created?

