### PR TITLE
fix(shopping-assistant): fix double agent name in response for customer service agent

### DIFF
--- a/services/shopping-assistant/config.yml
+++ b/services/shopping-assistant/config.yml
@@ -37,8 +37,14 @@ agents:
     llm: gpt-4o-mini
 
   shopping_actions:
+    name: shopping_actions
+    alias: Shopping Actions
+    
     prompts:
       system_prompt: |
+        Your designated name: shopping_actions
+        Your designated alias: Shopping Actions
+
         You are a helpful shopping assistant that can help users with their shopping needs.
         Based on the user's query, you do the following:
 
@@ -58,6 +64,9 @@ agents:
     llm: gpt-4o-mini
 
   product_search:
+    name: product_search
+    alias: Product Search
+
     catalog_hierarchy_tree: |
       Template:
       ```
@@ -83,6 +92,10 @@ agents:
       
     prompts:       
       system_prompt: |
+
+        Your designated name: product_search
+        Your designated alias: Product Search
+
         You are a shopping assistant, who helps users find products in an e-commerce store.
         You are given the product catalog hierarchy as follows:
         
@@ -117,9 +130,35 @@ agents:
     llm: gpt-4o-mini
 
   customer_service:
+    name: customer_service
+    alias: Customer Service
     prompts:
       system_prompt: |
-        You are a helpful customer service agent for an ecom websites. 
+        Your designated name: customer_service
+        Your designated alias: Customer Service
+
+        You are a helpful customer service agent for an e-commerce website.
         Answer any general chitchat questions as well as specific customer service questions for the user.
 
+        Analyze the provided conversation history with the user to re-examine if you are the right agent to answer the user's query.
+        The conversation history will clearly mention which agent has handled the user's query previously as follows:
+
+        If you (Customer Service) have handled the user's query previously:
+        ```
+        Customer Service Agent: ...
+        ```
+
+        If another agent has handled the user's query previously:
+
+        If it was handled by Product Search:
+        ```
+        Product Search Agent: ...
+        ```
+
+        If it was handled by Shopping Actions:
+        ```
+        Shopping Actions Agent: ...
+        ```
+
+        DO NOT include your designated name or alias in your response.
     llm: gpt-4o-mini


### PR DESCRIPTION
# Description

- Each time agent must response without mentioning its name or alias, since I already append it artifically later.
- Appending it separately can help the router agent better analyze what kind of queries has been routed to whom in the past, so helps with in context learning (TODO: #131 )
- Also add designated name / alias for `ProductSearch` and `CustomerService` agent in their system prompts (TODO: #132 )


The _state of the art_ engineering in this PR:

```yaml
DO NOT include your designated name or alias in your response.
```


Before:

<img width="1075" height="425" alt="image" src="https://github.com/user-attachments/assets/ed969899-a1af-45e0-962e-fb8086d004d0" />



After:

<img width="1073" height="811" alt="image" src="https://github.com/user-attachments/assets/725f8af1-cfc7-47f1-a99d-7792466c1461" />
