### PR TITLE
fix: pydantic v2 warnings for class bases config, and extra schema spec

### DIFF
--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/exceptions.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/exceptions.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ExceptionResponse(BaseModel):
@@ -6,8 +6,7 @@ class ExceptionResponse(BaseModel):
     detail: str
     error_code: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ApiError(Exception):

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/carts/types.py
@@ -1,28 +1,25 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class CartItemCreate(BaseModel):
     product_id: int
     quantity: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartCreateBody(BaseModel):
     cart_items: list[CartItemCreate]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartUpdateBody(BaseModel):
     cart_items: list[CartItemCreate]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartItemData(BaseModel):
@@ -31,8 +28,7 @@ class CartItemData(BaseModel):
     quantity: int
     amount: float
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartResponse(BaseModel):
@@ -41,5 +37,4 @@ class CartResponse(BaseModel):
     created_at: datetime
     cart_items: list[CartItemData]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/products/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/external/ecom_api_client/resources/products/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ProductResponse(BaseModel):
@@ -10,5 +10,4 @@ class ProductResponse(BaseModel):
     category_id: int
     subcategory_id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/packages/shopping-assistant/src/shopping_assistant/graph/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/graph/types.py
@@ -11,5 +11,9 @@ class State(BaseModel):
     messages: Annotated[list, add_messages_openai]
     prev_recommended_products: list[ProductVectorDBRecord] | None = None
     last_response_agent: str | None = Field(
-        default=None, choices=module_config.DOWNSTREAM_ROUTES, optional=True
+        default=None,
+        json_schema_extra={
+            "optional": True,
+            "choices": module_config.DOWNSTREAM_ROUTES,
+        },
     )

--- a/packages/shopping-assistant/src/shopping_assistant/types.py
+++ b/packages/shopping-assistant/src/shopping_assistant/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ProductVectorDBRecord(BaseModel):
@@ -18,5 +18,4 @@ class CartItem(BaseModel):
     product_id: int
     quantity: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/services/ecom-backend/core/config.py
+++ b/services/ecom-backend/core/config.py
@@ -1,11 +1,10 @@
+from pydantic import ConfigDict
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
     db_name: str
-
-    class Config:
-        env_file = ".env"
+    model_config = ConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/services/ecom-backend/domains/carts/schemas.py
+++ b/services/ecom-backend/domains/carts/schemas.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # TODO: Keeping the service layer schemas and API layer schemas same (for now).
 # Need to add clear separation later (Add api/schemas.py => request/response objects)
@@ -14,22 +14,19 @@ class CartItemCreate(BaseModel):
     product_id: int
     quantity: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartCreate(BaseModel):
     cart_items: list[CartItemCreate]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartUpdate(BaseModel):
     cart_items: list[CartItemCreate]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Output Schemas
@@ -41,8 +38,7 @@ class CartItemData(BaseModel):
     quantity: int
     amount: float
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CartData(BaseModel):
@@ -51,5 +47,4 @@ class CartData(BaseModel):
     created_at: datetime
     cart_items: list[CartItemData]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/services/ecom-backend/domains/products/schemas.py
+++ b/services/ecom-backend/domains/products/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 # Input Schemas
 
@@ -12,8 +12,7 @@ class ProductCreate(BaseModel):
     category_id: int
     subcategory_id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ProductUpdate(BaseModel):
@@ -24,8 +23,7 @@ class ProductUpdate(BaseModel):
     category_id: int | None = None
     subcategory_id: int | None = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
     # validate that atleast one is not None
     @model_validator(mode="after")
@@ -47,5 +45,4 @@ class ProductData(BaseModel):
     category_id: int
     subcategory_id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/services/ecom-backend/domains/users/schemas.py
+++ b/services/ecom-backend/domains/users/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # Output Schemas
 
@@ -12,5 +12,4 @@ class UserData(BaseModel):
     role: str
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
# Description


## Class based config depreciation

```diff
 class ExceptionResponse(BaseModel):
     detail: str
     error_code: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
```

## Extra schema options

```diff
class State(BaseModel):
     messages: Annotated[list, add_messages_openai]
     prev_recommended_products: list[ProductVectorDBRecord] | None = None
     last_response_agent: str | None = Field(
-        default=None, choices=module_config.DOWNSTREAM_ROUTES, optional=True
+        default=None,
+        json_schema_extra={
+            "optional": True,
+            "choices": module_config.DOWNSTREAM_ROUTES,
+        },
     )

```
