### PR TITLE
Enhance venv utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ ifndef COMPONENT
 	$(error COMPONENT is required. Usage: make venv-create COMPONENT=packages/shopping-assistant [GROUP=dev|prod])
 endif
 	@python3 scripts/create_venv.py --repo-root $(REPO_ROOT) --component $(COMPONENT) --group $(if $(GROUP),$(GROUP),prod)
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-clean
 venv-clean:
@@ -120,6 +123,9 @@ ifndef COMPONENT
 	$(error COMPONENT is required. Usage: make venv-clean COMPONENT=packages/shopping-assistant [GROUP=dev|prod])
 endif
 	@python3 scripts/clean_venv.py --repo-root $(REPO_ROOT) --component $(COMPONENT) $(if $(GROUP),--group $(GROUP),--clear-info)
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-create-all
 venv-create-all:
@@ -131,6 +137,9 @@ venv-create-all:
 	done
 	@echo ""
 	@echo "✓ All virtual environments created successfully"
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-clean-all
 venv-clean-all:
@@ -142,6 +151,9 @@ venv-clean-all:
 	done
 	@echo ""
 	@echo "✓ All virtual environments cleaned successfully"
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-refresh
 venv-refresh:
@@ -149,6 +161,9 @@ ifndef COMPONENT
 	$(error COMPONENT is required. Usage: make venv-refresh COMPONENT=packages/shopping-assistant [FIX=true])
 endif
 	@python3 scripts/refresh_info_json.py --repo-root $(REPO_ROOT) --component $(COMPONENT) $(if $(filter true,$(FIX)),--fix-active,)
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-refresh-all
 venv-refresh-all:
@@ -168,6 +183,9 @@ venv-refresh-all:
 		echo "⚠ $$failed component(s) had validation errors"; \
 		exit 1; \
 	fi
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-get-active venv-switch-all
 venv-get-active:
@@ -185,6 +203,9 @@ endif
 	done
 	@echo ""
 	@echo "✓ All virtual environments switched to $(TARGET) successfully"
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
 
 .PHONY: venv-switch
 venv-switch:
@@ -195,3 +216,6 @@ ifndef TARGET
 	$(error TARGET is required. Usage: make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev)
 endif
 	@python3 scripts/switch_venv.py --repo-root $(REPO_ROOT) --component $(COMPONENT) --target $(TARGET)
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ venv-refresh-all:
 		exit 1; \
 	fi
 
+.PHONY: venv-get-active
+venv-get-active:
+	@python3 scripts/get_active_venv.py --repo-root $(REPO_ROOT)
+
 .PHONY: venv-switch
 venv-switch:
 ifndef COMPONENT

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: all 
+.PHONY: all venv-switch-all
+
 
 REPO_ROOT := $(abspath $(PWD))
 export DOCKER_BUILDKIT=1
@@ -168,9 +169,22 @@ venv-refresh-all:
 		exit 1; \
 	fi
 
-.PHONY: venv-get-active
+.PHONY: venv-get-active venv-switch-all
 venv-get-active:
 	@python3 scripts/get_active_venv.py --repo-root $(REPO_ROOT)
+
+venv-switch-all:
+ifndef TARGET
+	$(error TARGET is required. Usage: make venv-switch-all TARGET=dev)
+endif
+	@echo "Switching virtual environments for all components..."
+	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+		echo ""; \
+		echo "==> Switching venv for $$component (TARGET=$(TARGET))..."; \
+		$(MAKE) venv-switch COMPONENT=$$component TARGET=$(TARGET) || exit 1; \
+	done
+	@echo ""
+	@echo "✓ All virtual environments switched to $(TARGET) successfully"
 
 .PHONY: venv-switch
 venv-switch:

--- a/scripts/get_active_venv.py
+++ b/scripts/get_active_venv.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Script to display venv status (active + options) for all monorepo components."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from list_components import list_components  # noqa: E402
+
+
+def get_venv_info(repo_root: Path, component: str) -> tuple[str, str]:
+    """Return (active, options_str) for a component from its .info.json."""
+    info_file = repo_root / component / ".info.json"
+    if not info_file.exists():
+        return "null", ""
+
+    with open(info_file) as f:
+        data = json.load(f)
+
+    venv = data.get("venv", {})
+    active = venv.get("active") or "null"
+    options = ", ".join(venv.get("options", []))
+    return active, options
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Display venv status for all monorepo components"
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root directory")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    components = list_components(repo_root)
+
+    rows = [(c, *get_venv_info(repo_root, c)) for c in components]
+
+    # Calculate column widths
+    headers = ("COMPONENT", "ACTIVE", "OPTIONS")
+    col_widths = [
+        max(len(headers[i]), max((len(row[i]) for row in rows), default=0))
+        for i in range(3)
+    ]
+
+    def fmt_row(cols):
+        return "  ".join(
+            col.ljust(col_widths[i]) for i, col in enumerate(cols)
+        ).rstrip()
+
+    print(fmt_row(headers))
+    print("  ".join("-" * w for w in col_widths))
+    for row in rows:
+        print(fmt_row(row))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/switch_venv.py
+++ b/scripts/switch_venv.py
@@ -50,6 +50,16 @@ def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # no
 
     current_active = data["venv"].get("active")
 
+    # Check if already active — must come before the existence check because when a
+    # venv is active its directory has been renamed to .venv, so target_venv_path
+    # won't exist as a physical directory.
+    if current_active == target_venv:
+        if default_venv.exists():
+            print(f"✓ {target_venv} is already the active venv, nothing to do")
+            return 0
+        print(f"⚠ {target_venv} is marked as active in .info.json but .venv is missing")
+        print("  Proceeding with switch to repair state...")
+
     # Check if target venv exists
     if not target_venv_path.exists():
         print(
@@ -73,14 +83,6 @@ def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # no
             )
 
         return 1
-
-    # Check if already active
-    if current_active == target_venv:
-        if default_venv.exists() and not target_venv_path.exists():
-            print(f"✓ {target_venv} is already active")
-            return 0
-        print(f"⚠ {target_venv} is marked as active but not properly switched")
-        print("  Proceeding with switch...")
 
     print(f"Switching to {target_venv} in {component}...")
 


### PR DESCRIPTION
  ## Summary                                                                                                          
                                                                                                                      
  Enhances the monorepo venv management tooling with three new capabilities and one bug fix.                          
                                                                                                                      
  ### New: `venv-get-active` — venv status table                                                                      

  Adds `scripts/get_active_venv.py` and a `make venv-get-active` target that prints a formatted, column-aligned table 
  of every component's current venv state:                                                                            

  ```
  COMPONENT                    ACTIVE      OPTIONS
  ---------------------------  ----------  -------------------------
  packages/shopping-assistant  .venv-dev   .venv-dev, .venv-prod
  services/ecom-backend        null
  services/shopping-assistant  .venv-prod  .venv-dev, .venv-prod
  ```

  ### New: `venv-switch-all` — batch venv switching

  Adds `make venv-switch-all TARGET=<group>` to switch all components to the same venv in one command, mirroring the
  existing `venv-create-all` / `venv-clean-all` pattern.

  ```bash
  make venv-switch-all TARGET=dev
  ```

  ### Improved: auto-display status after every mutating command

  `venv-get-active` is now automatically chained (with a separator) after every `venv-create`, `venv-clean`,
  `venv-refresh`, `venv-switch`, and their `-all` variants, so the current venv state is always visible after any
  operation.

  ### Fix: `venv-switch` no longer errors when target is already active

  `switch_venv.py` previously crashed with _"target venv doesn't exist"_ when switching to an already-active venv.
  When a venv is active, its directory is renamed to `.venv`, so the physical `.venv-<target>` path is absent — the
  existence check fired before the already-active guard. Fixed by reordering: check `.info.json`'s `active` field
  first, and return early with an informative message if the target is already active.

  ## Commits

  | SHA | Description |
  |-----|-------------|
  | `90104d5` | feat(venv): add `get_active_venv.py` script |
  | `6362996` | feat(venv): add `venv-get-active` Makefile target |
  | `d698436` | feat(venv): add `venv-switch-all` Makefile target |
  | `61c3067` | feat(venv): chain `venv-get-active` after every `venv-*` command |
  | `bc55204` | fix(venv): check already-active before existence check in `switch_venv.py` |

  ## Files changed

  - `scripts/get_active_venv.py` *(new)*
  - `scripts/switch_venv.py`
  - `Makefile`


>

Fully vibecoded with Claude Code 🤖 
PS: #124 task got more complex 🥲 