### PR TITLE
fix: last_response_agent not being set when agent outputs a product clarification response

### DIFF
--- a/packages/shopping-assistant/src/shopping_assistant/agent_definitions/product_search.py
+++ b/packages/shopping-assistant/src/shopping_assistant/agent_definitions/product_search.py
@@ -123,6 +123,7 @@ class ProductSearchAgent:
             new_state = State(
                 messages=[asst_message],
                 prev_recommended_products=state.prev_recommended_products,
+                last_response_agent=self.name,
             )
 
             return new_state


### PR DESCRIPTION
# Description

fix: last_response_agent not being set when agent outputs a product clarification response