### PR TITLE
Handle langfuse connectivity error, change otel logging to level: critical  

### DIFF
--- a/packages/shopping-assistant/src/shopping_assistant/chat.py
+++ b/packages/shopping-assistant/src/shopping_assistant/chat.py
@@ -22,6 +22,7 @@ from shopping_assistant.external.ecom_api_client.credentials import (
 )
 from shopping_assistant.graph.graph import build_graph
 from shopping_assistant.graph.types import State
+from shopping_assistant.observability.utils import langfuse_auth_check
 from shopping_assistant.tools.cart_actions import Cart
 
 
@@ -62,7 +63,7 @@ class Chat:
         if self.langfuse_client is not None:  # noqa: SIM102
             # TODO: Does this cause additional network I/O? Or can
             # LangfuseCallbackHandler gracefully fail if Langfuse is not available?
-            if self.langfuse_client.auth_check():
+            if langfuse_auth_check(self.langfuse_client):
                 base_conf["callbacks"] = [LangfuseCallbackHandler()]
         return base_conf
 

--- a/packages/shopping-assistant/src/shopping_assistant/observability/preflight.py
+++ b/packages/shopping-assistant/src/shopping_assistant/observability/preflight.py
@@ -24,6 +24,7 @@ def langfuse_auth_check_preflight() -> bool:
         return False
 
 
+# TODO: Add option of which loggers to set to CRITICAL level
 def setup_opentelemetry_logging():
     """
     Disable verbose opentelemetry logs.

--- a/packages/shopping-assistant/src/shopping_assistant/observability/preflight.py
+++ b/packages/shopping-assistant/src/shopping_assistant/observability/preflight.py
@@ -1,0 +1,36 @@
+import logging
+import os
+
+import httpx
+
+
+def langfuse_auth_check_preflight() -> bool:
+    host = os.getenv("LANGFUSE_HOST")
+    public = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret = os.getenv("LANGFUSE_SECRET_KEY")
+
+    if not host or not public or not secret:
+        return False
+
+    try:
+        r = httpx.get(
+            f"{host}/api/public/projects",
+            auth=(public, secret),
+            timeout=2,
+        )
+        return r.status_code == httpx.codes.OK
+
+    except Exception:
+        return False
+
+
+def setup_opentelemetry_logging():
+    """
+    Disable verbose opentelemetry logs.
+    """
+    for name in [
+        "opentelemetry.sdk._shared_internal",
+        "opentelemetry.exporter.otlp",
+        "opentelemetry.sdk.trace.export",
+    ]:
+        logging.getLogger(name).setLevel(logging.CRITICAL)

--- a/packages/shopping-assistant/src/shopping_assistant/observability/utils.py
+++ b/packages/shopping-assistant/src/shopping_assistant/observability/utils.py
@@ -2,9 +2,20 @@ import base64
 import logging
 import os
 
+import httpx
 import logfire
 from langfuse import Langfuse
 from langfuse import get_client as get_langfuse_client
+
+
+def langfuse_auth_check(langfuse: Langfuse) -> bool:
+    try:
+        auth_check = langfuse.auth_check()
+        logging.info("Langfuse authentication check: %s", auth_check)
+        return auth_check
+    except httpx.ConnectError as exc:
+        logging.error("Error checking Langfuse authentication: %s", exc)
+        return False
 
 
 def configure_langfuse() -> Langfuse:
@@ -26,7 +37,7 @@ def configure_langfuse() -> Langfuse:
     langfuse = get_langfuse_client()
 
     # BUG: logging doesn't show up
-    if langfuse.auth_check():
+    if langfuse_auth_check(langfuse):
         logging.info("Langfuse authentication successful")
     else:
         logging.warning("Langfuse authentication failed")

--- a/services/shopping-assistant/app.py
+++ b/services/shopping-assistant/app.py
@@ -10,7 +10,11 @@ from shopping_assistant.external.ecom_api_client.client import EcomAPIClient
 from shopping_assistant.external.ecom_api_client.credentials import (
     Credentials as EcomAPICredentials,
 )
+from shopping_assistant.observability.preflight import setup_opentelemetry_logging
 from shopping_assistant.observability.utils import configure_langfuse
+
+# TODO: Do this based on DEV, STAGING, PROD env (in DEV we want to see all logs)
+setup_opentelemetry_logging()
 
 VERSION = "0.1.0"
 


### PR DESCRIPTION
# Description

## Changes

1. Handle httpx.ConnectError timeout with langfuse auth check (Possibly raise / fix this in langfuse directly? #178)
2. Implement lighweight langfuse connectivity check `langfuse_auth_check_preflight` (just checks if `api/public/projects` is available) - This avoids langfuse connection automatic enabling of otel (??)
3. Set log level of annoying otel logs to `CRITICAL` (but what if want them?)

We expect langfuse to be up / down, and tracing should resume / pause gracefully without polluting the main app logs.


## Alternate

Earlier I tried disabling tracing if langfuse is not available but that's not ideal. 

```python
if langfuse_auth_check(langfuse):
    logging.info("Langfuse authentication successful")
else:
    logging.warning("Langfuse authentication failed")

    from opentelemetry import trace

    provider = trace.get_tracer_provider()
    try:
        provider.shutdown()
    except Exception:
        pass
```

The problem is, I would have the following scenarios: 

Scenario 1: Langfuse goes down midway 

1. App starts, Langfuse reachable 
4. Langfuse goes down 
5. Still get annoying otel logs 

Scenario 2: Langfuse comes up midway 

1. App starts, Langfuse not reachable 
2. Disable opentelemetry exporters 
3. Langfuse comes up 
6. Now tracing can't work 

## Reference

See more details here: https://chatgpt.com/c/699b0332-de78-8321-b47d-29bc89b9c9a3

