### PR TITLE
  fix(dev): Repair stale VIRTUAL_ENV paths in activate scripts after venv-switch

### DIFF
--- a/.claude/rules/venv-management.md
+++ b/.claude/rules/venv-management.md
@@ -93,10 +93,42 @@ make venv-switch COMPONENT=packages/shopping-assistant TARGET=prod
 **How switching works**:
 1. If venv already active: deactivates by renaming `.venv` → `.venv-{old}`
 2. Activates target: renames `.venv-{target}` → `.venv`
-3. Updates `.info.json` with `active: ".venv-{target}"`
-4. Updates `options` to include both physical `.venv-*` dirs and active venv
+3. Repairs stale `VIRTUAL_ENV` path references in `bin/` activate scripts (see below)
+4. Updates `.info.json` with `active: ".venv-{target}"`
+5. Updates `options` to include both physical `.venv-*` dirs and active venv
 
 **Important**: Target venv must exist before switching (create with `venv-create` first)
+
+### Repairing VIRTUAL_ENV References
+
+When a venv is renamed (e.g. `.venv-dev` → `.venv`), the activate scripts inside `bin/`
+still contain hardcoded paths to the old directory name. `venv-switch` repairs these
+automatically, but the targets below allow ad-hoc repairs if needed.
+
+**Repair active `.venv` for a single component**:
+```bash
+make venv-repair-refs COMPONENT=packages/shopping-assistant
+```
+
+**Repair a specific non-active venv**:
+```bash
+make venv-repair-refs COMPONENT=packages/shopping-assistant TARGET=dev
+```
+
+**Repair all components** (optional `TARGET` works here too):
+```bash
+make venv-repair-refs-all
+make venv-repair-refs-all TARGET=prod
+```
+
+**Dry-run to inspect without writing**:
+```bash
+python3 scripts/repair_venv_references.py \
+  --venv-dir packages/shopping-assistant [--target dev] --dry-run
+```
+
+The underlying script is `scripts/repair_venv_references.py` and is also importable
+as a module (`from repair_venv_references import repair_venv_references`).
 
 ### Refreshing .info.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all venv-switch-all
+.PHONY: all venv-switch-all venv-repair-refs venv-repair-refs-all
 
 
 REPO_ROOT := $(abspath $(PWD))
@@ -228,6 +228,24 @@ venv-lockfile-all:
 		--all-components \
 		--build-mode $(if $(BUILD_MODE),$(BUILD_MODE),local)
 
+
+.PHONY: venv-repair-refs
+venv-repair-refs:
+ifndef COMPONENT
+	$(error COMPONENT is required. Usage: make venv-repair-refs COMPONENT=packages/shopping-assistant [TARGET=dev])
+endif
+	@python3 scripts/repair_venv_references.py --venv-dir $(REPO_ROOT)/$(COMPONENT) $(if $(TARGET),--target $(TARGET),)
+
+.PHONY: venv-repair-refs-all
+venv-repair-refs-all:
+	@echo "Repairing venv references for all components..."
+	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+		echo ""; \
+		echo "==> Repairing venv refs for $$component..."; \
+		python3 scripts/repair_venv_references.py --venv-dir $(REPO_ROOT)/$$component $(if $(TARGET),--target $(TARGET),); \
+	done
+	@echo ""
+	@echo "✓ All venv references repaired successfully"
 
 .PHONY: venv-switch
 venv-switch:

--- a/scripts/repair_venv_references.py
+++ b/scripts/repair_venv_references.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Utility to repair stale VIRTUAL_ENV path references in venv activate scripts.
+
+After a venv directory is renamed (e.g. .venv-dev → .venv), the activate scripts
+inside bin/ still contain hardcoded paths to the old name. This script scans all
+regular files in bin/ and replaces any stale references with the correct current path.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def repair_venv_references(venv_dir: Path, dry_run: bool = False) -> int:
+    """Repair stale VIRTUAL_ENV path references in venv activate scripts.
+
+    Args:
+        venv_dir: Path to the venv directory (e.g. .venv or .venv-dev)
+        dry_run: If True, report changes without writing them
+
+    Returns:
+        0 on success, 1 on error
+    """
+    venv_dir = venv_dir.resolve()
+
+    if not venv_dir.exists():
+        print(f"Error: venv directory does not exist: {venv_dir}", file=sys.stderr)
+        return 1
+
+    bin_dir = venv_dir / "bin"
+    if not bin_dir.exists():
+        print(f"Error: bin/ directory not found in {venv_dir}", file=sys.stderr)
+        return 1
+
+    parent = re.escape(str(venv_dir.parent))
+    pattern = re.compile(rf"{parent}/\.venv(?:-[a-zA-Z0-9_-]*)?")
+    replacement = str(venv_dir)
+
+    updated = 0
+    for file_path in bin_dir.iterdir():
+        if not file_path.is_file():
+            continue
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, PermissionError):
+            continue
+
+        new_content = pattern.sub(replacement, content)
+        if new_content == content:
+            continue
+
+        prefix = "[dry-run] " if dry_run else ""
+        print(f"{prefix}Updated {file_path.name}: stale path → '{replacement}'")
+
+        if not dry_run:
+            file_path.write_text(new_content, encoding="utf-8")
+
+        updated += 1
+
+    if updated == 0:
+        print(f"No stale references found in {bin_dir}")
+    else:
+        action = "Would update" if dry_run else "Updated"
+        print(f"{action} {updated} file(s) in {bin_dir}")
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Repair stale VIRTUAL_ENV path references in venv activate scripts"
+    )
+    parser.add_argument(
+        "--venv-dir",
+        required=True,
+        help="Path to the component directory (e.g. packages/shopping-assistant)",
+    )
+    parser.add_argument(
+        "--target",
+        default=None,
+        help="Venv suffix to check (e.g. 'dev' checks .venv-dev). Omit to check .venv",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report changes without writing them",
+    )
+
+    args = parser.parse_args()
+    component_dir = Path(args.venv_dir)
+    venv_dir = component_dir / (f".venv-{args.target}" if args.target else ".venv")
+    sys.exit(repair_venv_references(venv_dir, dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/switch_venv.py
+++ b/scripts/switch_venv.py
@@ -8,8 +8,12 @@ import os
 import sys
 from pathlib import Path
 
+scripts_dir = Path(__file__).parent
+sys.path.insert(0, str(scripts_dir))
+from repair_venv_references import repair_venv_references  # noqa: E402
 
-def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # noqa: C901
+
+def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # noqa: C901,PLR0915
     """Switch to a different virtual environment.
 
     Args:
@@ -106,7 +110,10 @@ def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # no
     target_venv_path.rename(default_venv)
     print(f"  Renamed {target_venv} → .venv")
 
-    # Step 4: Update .info.json
+    # Step 4: Repair VIRTUAL_ENV path references in activate scripts
+    repair_venv_references(default_venv)
+
+    # Step 5: Update .info.json
     # Options should be union of physically present .venv-* and active venv
     venv_available = [
         os.path.basename(f) for f in glob.glob(str(component_path / ".venv-*"))


### PR DESCRIPTION
  ## Problem

  When venv-switch renames .venv-{target} → .venv, the activate scripts inside bin/ (e.g. activate, activate.fish,
  activate.csh) still contain hardcoded paths to the old directory name. This means running source .venv/bin/activate
  sets VIRTUAL_ENV to the wrong path (e.g. .venv-dev instead of .venv), breaking tooling that relies on it.

  ## Changes

  scripts/repair_venv_references.py (new)
  - Standalone CLI script and importable module
  - Scans all regular files in bin/, replaces any stale .venv or .venv-<suffix> sibling path references with the
  correct resolved path
  - CLI: --venv-dir <component-dir> (required), --target <suffix> (optional, defaults to .venv), --dry-run (optional)
  - Exports repair_venv_references(venv_dir, dry_run) for programmatic use

  scripts/switch_venv.py (edited)
  - Calls repair_venv_references() automatically after the rename step so every venv-switch corrects activate scripts
  in place

  Makefile (edited)
  - venv-repair-refs — repairs a single component's active venv; accepts optional TARGET to target .venv-{TARGET}
  instead
  - venv-repair-refs-all — repairs all components; also accepts optional TARGET

## Usage

```
  # Automatic — fix applied on every switch
  make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev

  # Ad-hoc repair of active .venv
  make venv-repair-refs COMPONENT=packages/shopping-assistant

  # Ad-hoc repair of a specific non-active venv
  make venv-repair-refs COMPONENT=packages/shopping-assistant TARGET=prod

  # Repair all components
  make venv-repair-refs-all

  # Dry-run inspection
  python3 scripts/repair_venv_references.py \
    --venv-dir packages/shopping-assistant --dry-run
```

##  Verification

```
  # After switch, VIRTUAL_ENV should end with /.venv — not /.venv-dev
  make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev
  source packages/shopping-assistant/.venv/bin/activate
  echo $VIRTUAL_ENV  # → .../packages/shopping-assistant/.venv
```

> Vibecoded with Claude Code 🤖 