### PR TITLE
feat(dev): setup direnv + venv autoswitching + custom venv prompt

### DIFF
--- a/.claude/rules/direnv-setup.md
+++ b/.claude/rules/direnv-setup.md
@@ -1,0 +1,91 @@
+# direnv Auto-activation Setup
+
+This document describes how direnv is configured to auto-activate Python virtual environments when `cd`-ing into project directories, with descriptive prompt names.
+
+## Prompt Format
+
+| Directory | Active venv | Prompt shows |
+|---|---|---|
+| repo root | `.venv` | `(root)` |
+| `packages/shopping-assistant` | `.venv-dev` active | `(packages/shopping-assistant@dev)` |
+| `services/ecom-backend` | `.venv-prod` active | `(services/ecom-backend@prod)` |
+| any | no `.venv` | reminder message |
+
+## One-time Machine Setup
+
+### 1. Install direnv
+```bash
+brew install direnv
+```
+
+### 2. Add to `~/.zshrc` (after `source $ZSH/oh-my-zsh.sh`)
+```zsh
+# Show active virtual environment in prompt (reads VIRTUAL_ENV_PROMPT set by direnv)
+function _venv_prompt_info() {
+  [[ -n "$VIRTUAL_ENV_PROMPT" ]] && echo -n "($VIRTUAL_ENV_PROMPT) "
+}
+PROMPT='$(_venv_prompt_info)'"$PROMPT"
+```
+
+### 3. Add direnv hook to `~/.zshrc` (end of file)
+```zsh
+eval "$(direnv hook zsh)"
+```
+
+### 4. Reload shell
+```bash
+source ~/.zshrc
+```
+
+## Per-clone Project Setup
+
+### 5. Generate and allow `.envrc` files
+```bash
+make direnv-setup
+```
+
+This creates `.envrc` in the repo root and each component directory, and runs `direnv allow` for each.
+
+### 6. Create venvs (prompt name is now baked in via `--prompt`)
+```bash
+make venv-create-all GROUP=dev
+```
+
+### 7. Activate a venv
+```bash
+make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev
+```
+
+After switching, `cd`-ing into the directory auto-activates the venv and updates the prompt.
+
+## Day-to-day Usage
+
+```bash
+cd packages/shopping-assistant
+# direnv: loading .envrc
+# prompt → (packages/shopping-assistant@dev) ➜ ...
+
+cd services/ecom-backend
+# direnv: loading .envrc
+# prompt → (services/ecom-backend@dev) ➜ ...
+
+cd ~
+# prompt → ➜ ...   (venv deactivated automatically)
+```
+
+If you see `direnv: no .venv found, run: make venv-create ...`:
+```bash
+make venv-create COMPONENT=<component> GROUP=dev
+make venv-switch COMPONENT=<component> TARGET=dev
+```
+
+If `.envrc` files are regenerated (`make direnv-setup`), direnv will prompt you to re-allow them — just run `make direnv-setup` again to re-allow automatically.
+
+## How It Works
+
+1. `make direnv-setup` writes `.envrc` to root + all components and runs `direnv allow` (using `cwd=` not a path arg)
+2. Each `.envrc` sets `VIRTUAL_ENV_DISABLE_PROMPT=1` before sourcing `.venv/bin/activate` — this prevents the activate script from modifying `PS1` directly (which would cause double prompt display)
+3. direnv exports `VIRTUAL_ENV_PROMPT` to the shell
+4. `_venv_prompt_info` in `~/.zshrc` reads `VIRTUAL_ENV_PROMPT` and prepends it to `$PROMPT` using `PROMPT_SUBST`
+
+The prompt name itself is baked into the venv at creation time via `uv venv --prompt {component}@{group}`, which sets it in `pyvenv.cfg` and all activate scripts.

--- a/Makefile
+++ b/Makefile
@@ -279,3 +279,10 @@ endif
 	@echo ""
 	@echo "----------------------------------------"
 	@$(MAKE) -s venv-get-active
+
+.PHONY: direnv-setup
+direnv-setup:
+	@echo "Setting up .envrc files..."
+	@python3 scripts/setup_direnv.py --repo-root $(REPO_ROOT)
+	@echo ""
+	@echo "✓ .envrc files created and allowed"

--- a/scripts/create_venv.py
+++ b/scripts/create_venv.py
@@ -117,8 +117,6 @@ def create_venv(repo_root: Path, component: str, group: str) -> int:
                 "uv",
                 "venv",
                 venv_name,
-                "--python",
-                "3.12",
                 "--prompt",
                 f"{component}@{group}",
             ],

--- a/scripts/create_venv.py
+++ b/scripts/create_venv.py
@@ -58,6 +58,36 @@ def get_path_dependencies(component_path: Path) -> list[tuple[str, Path]]:
         return []
 
 
+def patch_activate_scripts(venv_path: Path, prompt: str) -> None:
+    """Patch VIRTUAL_ENV_PROMPT in uv-generated activate scripts."""
+    patches = {
+        "bin/activate": (
+            'VIRTUAL_ENV_PROMPT=$(basename "$VIRTUAL_ENV")',
+            f'VIRTUAL_ENV_PROMPT="{prompt}"',
+        ),
+        "bin/activate.csh": (
+            'setenv VIRTUAL_ENV_PROMPT "$VIRTUAL_ENV:t:q"',
+            f"setenv VIRTUAL_ENV_PROMPT '{prompt}'",
+        ),
+        "bin/activate.fish": (
+            'set -gx VIRTUAL_ENV_PROMPT (basename "$VIRTUAL_ENV")',
+            f"set -gx VIRTUAL_ENV_PROMPT '{prompt}'",
+        ),
+        "bin/activate.ps1": (
+            "$env:VIRTUAL_ENV_PROMPT = $( Split-Path $env:VIRTUAL_ENV -Leaf )",
+            f'$env:VIRTUAL_ENV_PROMPT = "{prompt}"',
+        ),
+    }
+
+    for rel_path, (old, new) in patches.items():
+        script = venv_path / rel_path
+        if not script.exists():
+            continue
+        content = script.read_text()
+        if old in content:
+            script.write_text(content.replace(old, new))
+
+
 def create_venv(repo_root: Path, component: str, group: str) -> int:
     """Create a virtual environment for the specified component and group."""
     component_path = repo_root / component
@@ -83,10 +113,19 @@ def create_venv(repo_root: Path, component: str, group: str) -> int:
     # Create venv using uv
     try:
         subprocess.run(
-            ["uv", "venv", venv_name, "--python", "3.12"],
+            [
+                "uv",
+                "venv",
+                venv_name,
+                "--python",
+                "3.12",
+                "--prompt",
+                f"{component}@{group}",
+            ],
             cwd=component_path,
             check=True,
         )
+        # patch_activate_scripts(venv_path, f"{component}@{group}")
     except subprocess.CalledProcessError as e:
         print(f"Error creating venv: {e}", file=sys.stderr)
         return 1

--- a/scripts/setup_direnv.py
+++ b/scripts/setup_direnv.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate .envrc files for direnv auto-activation with custom venv prompt names."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from list_components import list_components
+
+ENVRC_TEMPLATE = """\
+if [ -d ".venv" ]; then
+  export VIRTUAL_ENV_DISABLE_PROMPT=1
+  source .venv/bin/activate
+else
+  echo "direnv: no .venv found, run: make venv-create COMPONENT={component} GROUP=dev"
+fi
+"""
+
+ROOT_ENVRC = """\
+if [ -d ".venv" ]; then
+  export VIRTUAL_ENV_DISABLE_PROMPT=1
+  source .venv/bin/activate
+else
+  echo "direnv: no .venv found at project root"
+fi
+"""
+
+
+def write_envrc(path: Path, content: str) -> None:
+    (path / ".envrc").write_text(content)
+    subprocess.run(["direnv", "allow"], cwd=str(path), check=True, capture_output=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate .envrc files for direnv auto-activation"
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root directory")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+
+    write_envrc(repo_root, ROOT_ENVRC)
+    print("  ✓ . (root)")
+
+    for component in list_components(repo_root):
+        write_envrc(repo_root / component, ENVRC_TEMPLATE.format(component=component))
+        print(f"  ✓ {component}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this does

Integrates https://direnv.net/ to automatically activate the correct Python virtual environment when cd-ing into any
 project directory. The active venv's prompt reflects the component and group, e.g.
(packages/shopping-assistant@dev) or (services/ecom-backend@prod).

---
## Changes

### Makefile — new direnv-setup target
```bash
make direnv-setup
```
Generates and allows .envrc files for the project root and all components (packages/*, services/*).

---
### scripts/setup_direnv.py (new file)

Generates .envrc files for each directory. Each file:
- Activates .venv if present (with VIRTUAL_ENV_DISABLE_PROMPT=1 to prevent the activate script from touching PS1)
- Prints a helpful reminder if .venv is missing
- Root gets a root label; components get {component}@{group} via VIRTUAL_ENV_PROMPT

---
### scripts/create_venv.py — two additions

1. uv venv now receives --prompt {component}@{group}, baking the display name into the venv's pyvenv.cfg and all
activate scripts at creation time:

- `packages/shopping-assistant@dev`
- `services/ecom-backend@prod`

2. patch_activate_scripts() added (call currently commented out) — a fallback that directly patches
VIRTUAL_ENV_PROMPT in bin/activate, activate.csh, activate.fish, activate.ps1 for cases where --prompt alone isn't
sufficient.

---
## One-time developer setup (not in repo)

~/.zshrc — two additions:

```bash
# direnv hook (auto-activate .envrc on cd)
eval "$(direnv hook zsh)"

# Show active venv in prompt
function _venv_prompt_info() {
  [[ -n "$VIRTUAL_ENV_PROMPT" ]] && echo -n "($VIRTUAL_ENV_PROMPT) "
}
PROMPT='$(_venv_prompt_info)'"$PROMPT"
```
---
## How-to Guide

Prerequisites (one-time per machine)

1. Install direnv
```bash
brew install direnv
```

3. Add to ~/.zshrc (after the source $ZSH/oh-my-zsh.sh line)
```bash
# direnv hook
eval "$(direnv hook zsh)"

# Venv prompt
function _venv_prompt_info() {
  [[ -n "$VIRTUAL_ENV_PROMPT" ]] && echo -n "($VIRTUAL_ENV_PROMPT) "
}
PROMPT='$(_venv_prompt_info)'"$PROMPT"
```

4. Reload your shell

```bash
source ~/.zshrc
```

---
## Project setup (one-time per clone)

6. Generate .envrc files and allow them

```bash
make direnv-setup
```

7. Create venvs (the --prompt flag is now applied automatically)
```bash
# All components at once
make venv-create-all GROUP=dev

# Or one at a time
make venv-create COMPONENT=packages/shopping-assistant GROUP=dev
make venv-create COMPONENT=services/ecom-backend GROUP=dev
make venv-create COMPONENT=services/shopping-assistant GROUP=dev
```

8. Activate a venv (renames .venv-dev → .venv)

```bash
make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev
```

---
## Day-to-day usage

```bash
cd packages/shopping-assistant
# direnv: loading .envrc
# prompt → (packages/shopping-assistant@dev) ➜ ...

cd services/ecom-backend
# direnv: loading .envrc
# prompt → (services/ecom-backend@dev) ➜ ...

cd ~
# prompt → ➜ ...  (venv deactivated automatically)
```

If you see direnv: no .venv found, run: make venv-create ...:

```bash
make venv-create COMPONENT=<component> GROUP=dev
make venv-switch COMPONENT=<component> TARGET=dev
```

If you recreate venvs, re-run make direnv-setup to re-allow the .envrc files (content changes invalidate the allow
hash).


> Crafted with ❤️  with ✴️ 