### PR TITLE
docs(shopping-assistant): Add comprehensive README for the shopping-assistant service 

### DIFF
--- a/playground/explore_shopping_assistant_service.sh
+++ b/playground/explore_shopping_assistant_service.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Multi-turn conversation exploring all four agents (user_id=1, thread_id=1)
+
+BASE_URL="http://localhost:8010"
+USER_ID="1"
+THREAD_ID="1"
+
+send() {
+  local label="$1"
+  local query="$2"
+  echo "=============================="
+  echo ">>> $label"
+  echo "Query: $query"
+  echo "Response:"
+  curl -s -X POST "$BASE_URL/chat" \
+    -H "Content-Type: application/json" \
+    -d "{\"user_id\": \"$USER_ID\", \"query\": \"$query\", \"thread_id\": \"$THREAD_ID\"}" | python3 -m json.tool
+  echo ""
+}
+
+# --- customer_service ---
+send "Turn 1 — CustomerServiceAgent (greeting)" \
+  "Hello!"
+
+# --- product_search ---
+send "Turn 2 — ProductSearchAgent (product discovery)" \
+  "I am looking for black sunglasses under 100 dollars"
+
+# --- shopping_actions ---
+send "Turn 3 — ShoppingActionsAgent (add to cart)" \
+  "Can you add the first one to my cart?"
+
+# --- customer_service ---
+send "Turn 4 — CustomerServiceAgent (return policy)" \
+  "What is your return policy?"

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -52,3 +52,37 @@ source .venv-dev/bin/activate
 uv pip install -e "." --group dev
 ```
 
+---
+
+## Dockerfile
+
+The Dockerfile uses a **multi-stage build** with a shared `base` stage and two targets: `dev` and `prod`.
+
+### Base stage
+
+Starts from `python:3.12-slim`, installs `uv`, and sets `/project` as the working directory.
+
+### Dev target
+
+- Copies `pyproject.toml` manifests first to maximise Docker layer caching
+- Copies the full service and package source (these are overridden by volume mounts at runtime, enabling hot reload)
+- Installs both the service and the `packages/shopping-assistant` package as **editable installs** (`-e`) with dev dependencies
+- Runs `uvicorn` with `--reload` on port `8010`
+
+To build and run the dev target, use the make target from the **repo root**:
+
+```bash
+make app-dev SERVICES=shopping-assistant
+```
+
+### Prod target
+
+- Copies source directly (no volume mounts)
+- Installs dependencies via `uv sync --locked --no-dev` — **no editable installs**, uses the lock file, dev dependencies excluded
+- Runs `uvicorn` without `--reload` on port `8010`
+
+To build and run the prod target, use the make target from the **repo root**:
+
+```bash
+make app-prod SERVICES=shopping-assistant
+```

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -222,3 +222,62 @@ For agent-level architecture details (agent prompts, graph state, routing logic)
 
 ---
 
+## Example Usage
+
+Multi-turn conversation with `user_id=1`, `thread_id=1`, covering all four agents.
+
+**Turn 1 — CustomerServiceAgent (greeting)**
+
+```bash
+curl -X POST 'http://localhost:8010/chat' \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "1", "query": "Hello!", "thread_id": "1"}'
+```
+
+```json
+{
+    "response": "Customer Service Agent: Hello! How can I assist you today?"
+}
+```
+
+**Turn 2 — ProductSearchAgent (product discovery)**
+
+```bash
+curl -X POST 'http://localhost:8010/chat' \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "1", "query": "I am looking for black sunglasses under 100 dollars", "thread_id": "1"}'
+```
+
+```json
+{
+    "response": "Product Search Agent: I found the following products based on your query:\n\n1. trendy-tapered-sunglasses ($49.99)\n2. futura-sunglasses-in-aviator-style ($99.99)\n3. ivory-glitter-cat-eye-sunglasses ($99.99)\n4. vivid-rose-gold-aviator-sunglasses ($69.99)\n5. kaleidoscope-mirror-sunglasses ($49.99)"
+}
+```
+
+**Turn 3 — ShoppingActionsAgent (add to cart)**
+
+```bash
+curl -X POST 'http://localhost:8010/chat' \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "1", "query": "Can you add the first one to my cart?", "thread_id": "1"}'
+```
+
+```json
+{
+    "response": "Shopping Actions Agent: The \"Trendy Tapered Sunglasses\" have been successfully added to your cart.\n\n### Current Cart:\n| Sno | Product                    | Qty | Amount  |\n|-----|----------------------------|-----|---------|\n| 1   | Southwest Bracelet         | 3   | $509.97 |\n| 2   | Floral Choker Necklace     | 2   | $259.98 |\n| 3   | Ivy Leaf Embroidered Skirt | 1   | $189.99 |\n| 4   | Trendy Tapered Sunglasses  | 2   | $99.98  |\n\n**Total: $1059.92**"
+}
+```
+
+**Turn 4 — CustomerServiceAgent (return policy)**
+
+```bash
+curl -X POST 'http://localhost:8010/chat' \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "1", "query": "What is your return policy?", "thread_id": "1"}'
+```
+
+```json
+{
+    "response": "Customer Service Agent: Our return policy allows you to return most items within 30 days of receiving your order. Items must be unused, in their original packaging, and include all tags and labels. To initiate a return, visit the returns section of our website or contact customer service."
+}
+```

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -86,3 +86,27 @@ To build and run the prod target, use the make target from the **repo root**:
 ```bash
 make app-prod SERVICES=shopping-assistant
 ```
+
+---
+
+## Setting Up External Connections
+
+### Service port
+
+| Variable | Description | Internal Port | Forwarded Port |
+|---|---|---|---|
+| `SHOPPING_ASSISTANT_PORT` | Port this service listens on | `8010` | `8010` |
+
+### External services
+
+This service connects to the following external services at runtime:
+
+| Service | Purpose |
+|---|---|
+| Weaviate | Vector search for product retrieval |
+| Ecom Backend API | Cart and product operations |
+| LLM provider | OpenAI / Anthropic / Cohere |
+| Langfuse | LLM observability (optional) |
+
+For the full list of env vars for each of these services, see [Setting Up External Connections](../../packages/shopping-assistant/README.md#setting-up-external-connections) in the `packages/shopping-assistant` README.
+

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -149,3 +149,58 @@ services/shopping-assistant/
 
 ---
 
+## Architecture
+
+The service exposes a single `POST /chat` endpoint that drives the multi-agent LangGraph pipeline from the `shopping-assistant` package.
+
+```mermaid
+graph TD
+    Client(["HTTP Client"])
+
+    subgraph SVC["shopping-assistant service"]
+        API["POST /chat"]
+        START(["START"])
+        END(["END"])
+
+        API --> START
+        START -->|"conditional edge"| Router
+
+        subgraph Router["RouterAgent"]
+            R["Classify intent"]
+        end
+
+        Router -->|product_search| PS
+        Router -->|shopping_actions| SA
+        Router -->|customer_service| CS
+
+        subgraph PS["ProductSearchAgent"]
+            PS1["Parse query + semantic search"]
+        end
+
+        subgraph SA["ShoppingActionsAgent"]
+            SA1["Cart operations via tools"]
+        end
+
+        subgraph CS["CustomerServiceAgent"]
+            CS1["General support & FAQ"]
+        end
+
+        PS --> END
+        SA --> END
+        CS --> END
+    end
+
+    Client -->|"POST /chat"| API
+    END -->|"JSON response"| Client
+
+    PS1 <-->|"WeaviateConnectionManager"| Weaviate[("Weaviate<br>vector DB")]
+    SA1 <-->|"EcomAPIClient"| EcomAPI[("Ecom<br>Backend API")]
+
+    subgraph Footer["LLM Observability Layer (Langfuse)"]
+    end
+```
+
+For agent-level architecture details (agent prompts, graph state, routing logic), see the [Architecture](../../packages/shopping-assistant/README.md#architecture) section of the `packages/shopping-assistant` README.
+
+---
+

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -110,3 +110,24 @@ This service connects to the following external services at runtime:
 
 For the full list of env vars for each of these services, see [Setting Up External Connections](../../packages/shopping-assistant/README.md#setting-up-external-connections) in the `packages/shopping-assistant` README.
 
+---
+
+## How to Run
+
+Environment variables are configured in the `platform/app/` directory. Use the provided example files as a reference:
+
+- `platform/app/.env.example` — prod
+- `platform/app/.env.dev.example` — dev
+
+Copy the relevant example to `.env` / `.env.dev` and fill in your values before running.
+
+To run the service via Docker Compose from the **repo root**:
+
+```bash
+# Dev (hot reload, editable installs)
+make app-dev SERVICES=shopping-assistant
+
+# Prod
+make app-prod SERVICES=shopping-assistant
+```
+

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -1,0 +1,54 @@
+# shopping-assistant service
+
+The FastAPI web app service that exposes the GenAI Shopping Assistant, backed by the [`shopping-assistant`](../../packages/shopping-assistant/README.md) package.
+
+---
+
+## Setting Up Dev Environment
+
+### Prerequisites
+
+- Python 3.12
+- [`uv`](https://docs.astral.sh/uv/) — used for virtual environment and dependency management
+
+### Option A: Using Make targets (recommended)
+
+From the **repo root**:
+
+```bash
+# Create the dev virtual environment (editable install)
+make venv-create COMPONENT=services/shopping-assistant GROUP=dev
+
+# Activate it
+source services/shopping-assistant/.venv-dev/bin/activate
+```
+
+To switch between `dev` and `prod` environments:
+
+```bash
+# Switch active venv to dev
+make venv-switch COMPONENT=services/shopping-assistant TARGET=dev
+
+# Then activate
+source services/shopping-assistant/.venv/bin/activate
+```
+
+> See the repo root `README.md` and `.claude/rules/venv-management.md` for full venv management documentation.
+
+### Option B: Manual uv install (editable)
+
+From the **repo root**:
+
+```bash
+cd services/shopping-assistant
+
+# Create a virtual environment
+uv venv --python 3.12 .venv-dev
+
+# Activate it
+source .venv-dev/bin/activate
+
+# Install the package in editable mode with dev dependencies
+uv pip install -e "." --group dev
+```
+

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -131,3 +131,21 @@ make app-dev SERVICES=shopping-assistant
 make app-prod SERVICES=shopping-assistant
 ```
 
+---
+
+## Tree Structure
+
+```
+services/shopping-assistant/
+├── app.py                          # FastAPI app — routes and startup
+├── Dockerfile                      # Multi-stage build (dev / prod)
+├── pyproject.toml                  # Dependencies and build config
+├── uv.lock                         # Locked dependency versions
+├── .shopping-assistant/
+│   └── config/config.yml           # Agent and LLM config (overrides package default)
+└── scripts/
+    └── ingest_product_data_into_vectorstore.py  # One-off product ingestion script
+```
+
+---
+

--- a/services/shopping-assistant/README.md
+++ b/services/shopping-assistant/README.md
@@ -204,3 +204,21 @@ For agent-level architecture details (agent prompts, graph state, routing logic)
 
 ---
 
+## API Routes
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/` | Service info and available endpoints |
+| `GET` | `/health` | Health check |
+| `POST` | `/chat` | Send a message to the shopping assistant |
+
+### `POST /chat` request body
+
+| Field | Type | Description |
+|---|---|---|
+| `user_id` | `str` | User identifier |
+| `thread_id` | `str` | Conversation thread identifier |
+| `query` | `str` | User message |
+
+---
+


### PR DESCRIPTION
## Summary

This PR adds a detailed `README.md` for `services/shopping-assistant` — the core GenAI multi-agent chat service. The document was built iteratively using Claude Code, with an exploration environment provided to hit the API live and produce real example outputs. 


## README

The README was written section-by-section, with each section added as an individual commit to make the authoring process reviewable. Sections added:

- **Setting Up Dev Environment** — Make target workflow and manual `uv` install (editable mode)
- **Dockerfile** — Explains the `dev` and `prod` targets (**multi-stage build**) 
- **Setting Up External Connections** — Weaviate, Ecom Backend API, LLM provider keys, and Langfuse; references `shopping-assistant create new .` to scaffold `.env.example`
- **How to Run** — Defines how to spin up the service
- **Tree Structure** — Annotated directory tree of `services/shopping_assistant/`
- **API Routes** — Documents the API routes
- **Example Usage** — Example HTTP request and response for `/chat` route


## How Claude Code was used to document

Lemme explain this, since I don't wanna waste too much tokens.

The README was built iteratively using Claude Code over multiple sessions, following a structured task list defined in `.wip/docs/svc-shopping-assistant/TODO.md`.

Contents of `TODO.md`

```markdown
# Document `services/shopping-assistant`


## Goal

Add a well documented `README.md`

## How to explore:

### Explore through codebase tree

- See the tree structure of the codebase
- Analyze the current task you are doing (i.e. a particular section / checklist of `Main Task`)
- Then explore that part of the code to document better

### [IMPORTANT] Explore through `packages/shopping-assistant` README.md

It is extremely IMPORTANT that you keep referring to this when you are iteratively building a documentation for `services/shopping-assistant`

- In a previous session, you already documented the underlying python package in its README file
- Use this heavily as a reference to understand the README structure previously developed as well as agentic AI functionality.


## Main Task

Document `README.md`:

- [ ] Setting up dev environment (local venv)


    - You can mention to use venv management make targets
    - Alternatively, use `dev` group and create a uv python env command (editable)

- [ ] Dockerfile

Explain basic structure of dockerfile here

    - Dev environment:
        - Explain dev target
        - Mention command as `make app`
    
    - Prod Environment:
        - No editable installs

- [ ] Setting up external connections

    - Mention the port env vars for this service (`SHOPPING_ASSISTANT_PORT=8010`)
    - Mention briefly a table for other services (no specific env vars details)
        - Now just add a reference to `Setting Up External Connections` section of `packages/shopping-assistant/README.md`

- [ ] How to run

    - Specify env vars in `platform/app/.env` (prod) and `platform/app/.env.dev`
    - Mention to run the docker compose command through repo root make targets 
        - `make app-run-dev SERVICES=shopping-assistant`
        - `make local-app-dev SERVICES=shopping-assistant`

- [ ] Tree Diagram

    - Explore the directory tree structure of the package (`services/shopping-assistant`)
    - Make a small tree diagram

- [ ] Architecture


    - See the mermaid diagram in `packages/shopping-assistant/README.md` and alter it as follows
        - Encapsulate the langgraph nodes with a `shopping-assistant` service API (which is `/chat`)
        - Draw a simple mermaid diagram
    - Mention, agent specific architecture details are present in `Architecture` section of  `packages/shopping-assistant/README.md`


-  [ ] API Routes

    - Document the API routes as a tabular summary

- [ ] Example Usage

Here you need to explore the API route `/chat` as follows:

- All the dependent services (ECOM BACKEND API, WEAVIATE have been setup) - No need for you to check for this
- The API can be accessed at `http://localhost:8010` 
    - Hit the different routes (See `services/shopping-assistant/app.py` for routes)
        - `/`
        - `/health`
        

Here is an example request for `/chat`:

`
curl -X 'POST' \
  'http://localhost:8010/chat' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "user_id": "1",
  "query": "Hi",
  "thread_id": "1"
}'
`

Your task for this section:
    - Add these curl commands and output for different example queries which explore each agent (router, product_search, customer_service, shopping_actions). Keep user_id and thread as 1.


```

This is how my convo looked with claude code. I asked claude to tell me what convo we had as we iteratively built the docs. 

```bash
❯ Can you output here the in line instructions I gave you in this chat as a dash list per section? Do not include     
   the instructions in TODO.md. I just want the conversations we had.                                                
                                                                                                                      
⏺ Here are the inline instructions you gave per section:                                                              
                                                   
  - Section 1 (Dev environment): (no additional instructions — proceeded directly from TODO)                          
  - Section 2 (Dockerfile): This is a FastAPI web app and NOT a Gradio web app.
  - Section 3 (External connections): Do not add redundant details, but still add relevant context to README, and then
   add a reference to the shopping-assistant package relevant README section.
  - Section 4 (How to run): This should be a brief section. Mention that there are .env.example files for reference in
   platform/*.
  - Section 5 (Tree diagram): Add the tree diagram and comments alongside in the tree. Super simple and brief.
  - Section 6 (Architecture): Remember to make relevant edits to the mermaid diagram.
  - Section 7 (API routes): Keep it super brief, just a tabular summary.
  - Section 8 (Example usage): Create a bash script in playground called explore_shopping_assistant_service.sh. Focus
  on /chat with a multi-turn conversation with user_id=1, thread_id=1. See the config for example queries.
```


For documenting `Example Usage`, I had already spun up the services, and gave claude the environment to hit the API, and it came up with `playground/explore_shopping_assistant_service.sh`