### PR TITLE
docs: fix langfuse mmd arch in monorepo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,10 @@ flowchart TB
     subgraph vpc["VPC"]
         Web["Web Server<br/>(langfuse/langfuse)"]
         Worker["Async Worker<br/>(langfuse/worker)"]
-        Postgres@{ img: "/images/logos/postgres_icon.svg", label: "Postgres - OLTP\n(Transactional Data)", pos: "b", w: 60, h: 60, constraint: "on" }
-        Cache@{ img: "/images/logos/redis_icon.png", label: "Redis\n(Cache, Queue)", pos: "b", w: 60, h: 60, constraint: "on" }
-        Clickhouse@{ img: "/images/logos/clickhouse_icon.svg", label: "Clickhouse - OLAP\n(Observability Data)", pos: "b", w: 60, h: 60, constraint: "on" }
-        S3@{ img: "/images/logos/s3_icon.svg", label: "S3 / Blob Storage\n(Raw events, multi-modal attachments)", pos: "b", w: 60, h: 60, constraint: "on" }
+        Postgres@{label: "Postgres - OLTP\n(Transactional Data)", pos: "b", w: 60, h: 60, constraint: "on"}
+        Cache@{label: "Redis\n(Cache, Queue)", pos: "b", w: 60, h: 60, constraint: "on"}
+        Clickhouse@{label: "Clickhouse - OLAP\n(Observability Data)", pos: "b", w: 60, h: 60, constraint: "on"}
+        S3@{label: "S3 / Blob Storage\n(Raw events, multi-modal attachments)", pos: "b", w: 60, h: 60, constraint: "on"}
     end
     LLM["LLM API/Gateway<br/>(optional; BYO; can be same VPC or VPC-peered)"]
 


### PR DESCRIPTION
ooops! when you use too much AI, you definitely lose the patience to review stuff! missed langfuse mermaid diagram not rendering in the monorepo `README.md` due to having references to tech stack png image resources. Removed the reference to images now.

