### PR TITLE
Add root project venv support to monorepo venv management utilities

### DIFF
--- a/.claude/rules/venv-management.md
+++ b/.claude/rules/venv-management.md
@@ -15,15 +15,25 @@ The monorepo uses a standardized virtual environment management system with Make
 - `.venv-{group}`: Custom group virtual environment
 - `.venv`: Active/current virtual environment (renamed from `.venv-{id}`)
 
+**Component Identification**:
+Components are identified by path in make targets:
+- `root` - Special identifier for the repository root directory itself
+- `packages/shopping-assistant` - Components under packages/
+- `services/ecom-backend` - Components under services/
+
 **State Tracking (`.info.json`)**:
 Each component has a `.info.json` file with `venv` key that tracks:
 - `options`: Array of ALL available venvs (union of physical `.venv-*` directories + active venv)
 - `active`: Currently active venv name (what `.venv` represents), or `null` if none active
+- Located at component root: `/.info.json` (for root), `packages/shopping-assistant/.info.json`, etc.
 
 ### Creating Virtual Environments
 
 **Create venv for a single component**:
 ```bash
+# Create root dev venv (editable install)
+make venv-create COMPONENT=root GROUP=dev
+
 # Create dev venv (editable install)
 make venv-create COMPONENT=packages/shopping-assistant GROUP=dev
 
@@ -34,14 +44,23 @@ make venv-create COMPONENT=services/ecom-backend GROUP=prod
 make venv-create COMPONENT=services/shopping-assistant GROUP=test
 ```
 
+**Special: Root project venvs**:
+The special component identifier `"root"` refers to the repository root itself:
+- Maps to the root `/pyproject.toml` and root directory
+- Useful for monorepo-level tools (pre-commit, documentation generators, etc.)
+- Venvs created at repository root: `.venv-dev/`, `.venv-prod/`, etc.
+- State tracked in `/.info.json`
+
 **Create venvs for all components at once**:
 ```bash
-# Create dev venvs for all components
+# Create dev venvs for all components (including root)
 make venv-create-all GROUP=dev
 
-# Create prod venvs for all components
+# Create prod venvs for all components (including root)
 make venv-create-all GROUP=prod
 ```
+
+**Note**: `venv-create-all` processes all components in order: `root` first, then packages and services. Root is always the first component in the list.
 
 **What happens during creation**:
 1. Creates `.venv-{group}` directory using `uv venv --python 3.12`
@@ -212,15 +231,51 @@ make venv-pin-python-all
 make venv-pin-python-all PYTHON_VERSION=3.13
 ```
 
+### Root Project Venv
+
+The repository root has its own `pyproject.toml` with root-level dependencies:
+
+```toml
+[dependency-groups]
+dev = [
+    "pre-commit"
+]
+```
+
+**Create and use root dev venv**:
+```bash
+# Create root dev venv with pre-commit and dependencies
+make venv-create COMPONENT=root GROUP=dev
+
+# Switch to root dev venv
+make venv-switch COMPONENT=root TARGET=dev
+
+# Activate the root venv
+source .venv/bin/activate
+
+# Verify pre-commit is available
+pre-commit --version
+```
+
+**Root venv use cases**:
+- Install monorepo-level tools (pre-commit, documentation generators)
+- Run root-level scripts and utilities
+- Create isolated root environment for container builds
+- Pin development tools independent of component venvs
+
 ### Common Venv Workflows
 
 **Setting up a new development environment**:
 ```bash
-# Create dev venvs for all components
+# Create dev venvs for all components (including root)
 make venv-create-all GROUP=dev
 
-# Activate the venv for the component you're working on
-source packages/shopping-assistant/.venv-dev/bin/activate
+# Activate the root venv (for pre-commit and monorepo tools)
+make venv-switch COMPONENT=root TARGET=dev
+source .venv/bin/activate
+
+# Then activate the venv for the component you're working on
+source packages/shopping-assistant/.venv/bin/activate
 
 # Verify all .info.json files are valid
 make venv-refresh-all

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.info.json
 
 # mypy
 .mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "project"
+version = "0.1.0"
+
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = [
+    "pre-commit"
+]
+
+[tool.setuptools]
+packages = []

--- a/scripts/build_venv_lockfile_local.py
+++ b/scripts/build_venv_lockfile_local.py
@@ -53,7 +53,12 @@ def main() -> int:
         for component in components:
             print()
             print(f"==> {component}")
-            result = build_lockfile(repo_root / component)
+            if component == "root":
+                component_path = repo_root
+            else:
+                component_path = repo_root / component
+
+            result = build_lockfile(component_path)
             if result != 0:
                 failed += 1
 
@@ -64,7 +69,12 @@ def main() -> int:
 
         print("✓ All lockfiles built successfully")
         return 0
-    component_path = repo_root / args.component
+
+    if args.component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / args.component
+
     if not component_path.exists():
         print(
             f"Error: Component path does not exist: {component_path}",

--- a/scripts/clean_venv.py
+++ b/scripts/clean_venv.py
@@ -23,7 +23,10 @@ def clean_venvs(  # noqa: C901, PLR0912
             If None, cleans all venvs.
         clear_info: Whether to clear the .info.json file after cleaning
     """
-    component_path = repo_root / component
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
 
     if not component_path.exists():
         print(

--- a/scripts/create_venv.py
+++ b/scripts/create_venv.py
@@ -88,9 +88,13 @@ def patch_activate_scripts(venv_path: Path, prompt: str) -> None:
             script.write_text(content.replace(old, new))
 
 
-def create_venv(repo_root: Path, component: str, group: str) -> int:
+def create_venv(repo_root: Path, component: str, group: str) -> int:  # noqa: C901, PLR0912
     """Create a virtual environment for the specified component and group."""
-    component_path = repo_root / component
+
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
 
     if not component_path.exists():
         print(

--- a/scripts/get_active_venv.py
+++ b/scripts/get_active_venv.py
@@ -12,7 +12,13 @@ from list_components import list_components  # noqa: E402
 
 def get_venv_info(repo_root: Path, component: str) -> tuple[str, str]:
     """Return (active, options_str) for a component from its .info.json."""
-    info_file = repo_root / component / ".info.json"
+
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
+
+    info_file = component_path / ".info.json"
     if not info_file.exists():
         return "null", ""
 

--- a/scripts/list_components.py
+++ b/scripts/list_components.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def list_components(repo_root: Path) -> list[str]:
     """Find all components with pyproject.toml files."""
-    components = []
+    components = ["root"]
 
     # Search in packages/ and services/ directories
     search_dirs = ["packages", "services"]
@@ -28,7 +28,7 @@ def list_components(repo_root: Path) -> list[str]:
             component_path = pyproject_file.parent.relative_to(repo_root)
             components.append(str(component_path))
 
-    return sorted(components)
+    return [components[0]] + sorted(components[1:])
 
 
 def main():

--- a/scripts/refresh_info_json.py
+++ b/scripts/refresh_info_json.py
@@ -20,7 +20,10 @@ def refresh_info_json(repo_root: Path, component: str, fix_active: bool = False)
     Returns:
         0 if successful, 1 if there are validation errors
     """
-    component_path = repo_root / component
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
 
     if not component_path.exists():
         print(

--- a/scripts/switch_venv.py
+++ b/scripts/switch_venv.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(scripts_dir))
 from repair_venv_references import repair_venv_references  # noqa: E402
 
 
-def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # noqa: C901,PLR0915
+def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # noqa: C901,PLR0915,PLR0912
     """Switch to a different virtual environment.
 
     Args:
@@ -24,7 +24,10 @@ def switch_venv(repo_root: Path, component: str, target_venv: str) -> int:  # no
     Returns:
         0 if successful, 1 if there are errors
     """
-    component_path = repo_root / component
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
 
     if not component_path.exists():
         print(

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,162 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pre-commit" }]
+
+[[package]]
+name = "python-discovery"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+]


### PR DESCRIPTION
## Summary

This PR extends the venv management utilities to support creating, managing, and switching virtual environments at the repository root level. Previously, virtual environments could only be created for components in `packages/` and `services/` directories. Now the root project itself can have dedicated `dev` and `prod` venvs, enabling consistent development workflows and environment management across the entire monorepo.

## Changes

### 1. Root Project Configuration

#### New pyproject.toml at repository root
Added `/pyproject.toml` with minimal configuration to enable PEP 735 dependency groups and make the root a recognized component:

```toml
[build-system]
requires = ["setuptools", "wheel"]
build-backend = "setuptools.build_meta"

[project]
name = "project"
version = "0.1.0"
requires-python = ">=3.12"

[dependency-groups]
dev = [
    "pre-commit"
]

[tool.setuptools]
packages = []
```

This allows the root to define dev dependencies (pre-commit) and enables proper uv lockfile generation for the root environment.

#### Updated .gitignore
Added `.info.json` to `.gitignore` to exclude venv state tracking files from git:

```diff
+.info.json
```

This prevents accidental commits of component-specific venv metadata.

### 2. Component Discovery System

#### Modified `scripts/list_components.py`
Updated to include `"root"` as the first recognized component:

```python
def list_components(repo_root: Path) -> list[str]:
    """Find all components with pyproject.toml files."""
    components = ["root"]  # Now includes root

    # ... search in packages/ and services/ ...

    return [components[0]] + sorted(components[1:])  # Keeps root first
```

The `"root"` string is now treated as a special component identifier that maps to `repo_root` in the venv management scripts.

### 3. Venv Scripts Updates

All venv management scripts were updated to handle the special `"root"` component identifier by converting it to the actual `repo_root` path:

#### `scripts/create_venv.py`
```python
def create_venv(repo_root: Path, component: str, group: str) -> int:
    if component == "root":
        component_path = repo_root
    else:
        component_path = repo_root / component
    # ... rest of logic
```

#### `scripts/clean_venv.py`
```python
if component == "root":
    component_path = repo_root
else:
    component_path = repo_root / component
```

#### `scripts/switch_venv.py`
```python
if component == "root":
    component_path = repo_root
else:
    component_path = repo_root / component
```

#### `scripts/refresh_info_json.py`
```python
if component == "root":
    component_path = repo_root
else:
    component_path = repo_root / component
```

#### `scripts/get_active_venv.py`
```python
if component == "root":
    component_path = repo_root
else:
    component_path = repo_root / component

info_file = component_path / ".info.json"
```

#### `scripts/build_venv_lockfile_local.py`
```python
if component == "root":
    component_path = repo_root
else:
    component_path = repo_root / component

result = build_lockfile(component_path)
```

### 4. Lockfile Generation

#### Generated `uv.lock` at repository root
Created `/uv.lock` with dependencies resolved for the root project's `pyproject.toml`:

```
version = 1
revision = 3
requires-python = ">=3.12"

[[package]]
name = "pre-commit"
version = "4.5.1"
...
```

This lockfile pins all dev dependencies (pre-commit and transitive dependencies) to ensure reproducible root environment creation.

## Benefits

1. **Unified Development Environment**: All developers can create and activate a consistent root dev environment with pre-commit hooks and other monorepo-level tools.

2. **Simplified Venv Management**: The venv utilities now treat all components uniformly—root is just another component with a special identifier `"root"` that maps to `repo_root`.

3. **Production-Ready Root Venv**: Teams can now create production venvs at the root level for deployment scenarios requiring isolated root-level dependencies.

4. **Cleaner Code**: Root path handling is transparent and consistent across all scripts using the `component == "root"` pattern.

5. **Future-Proof Architecture**: Extends the venv management system to support additional use cases (e.g., container images built from root venv, monorepo-level tools).

## Testing

### Create root dev venv
```bash
make venv-create COMPONENT=root GROUP=dev
```

Expected output:
- `.venv-dev/` created in repository root
- `root/.info.json` updated with `options: [".venv-dev"]` and `active: null`
- `uv.lock` used for reproducible dependency installation

### Switch to root dev venv
```bash
make venv-switch COMPONENT=root TARGET=dev
```

Expected output:
- `.venv/` symlinked from `.venv-dev/`
- Activate script can source: `source .venv/bin/activate`
- Prompt shows `(root@dev)` in direnv-enabled shells

### Create root prod venv
```bash
make venv-create COMPONENT=root GROUP=prod
```

Expected output:
- `.venv-prod/` created with non-editable pre-commit
- `root/.info.json` updated with `options: [".venv-dev", ".venv-prod"]`

### Clean root venvs
```bash
make venv-clean COMPONENT=root
```

Expected output:
- Both `.venv-dev/` and `.venv-prod/` removed
- `root/.info.json` reset to empty state

### List all components including root
```bash
python scripts/list_components.py --repo-root .
```

Expected output:
```
root
packages/shopping-assistant
services/ecom-backend
services/shopping-assistant
```