### PR TITLE
Fix prerelease version naming and bumping logic

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,14 +25,14 @@ This document describes the release workflow for the GenAI Shopping Assistant mo
 develop branch
     ↓
 Trigger: workflow_dispatch
-Tag: v0.1.0-dev1 (no GitHub release)
+Tag: v0.1.0-dev.1 (no GitHub release)
     ↓
     └─→ Cut release/v0.1.0 branch
             ↓
         Trigger: workflow_dispatch (per RC)
-        Tag: v0.1.0-rc0, v0.1.0-rc1, ... (pre-release)
+        Tag: v0.1.0-rc.0, v0.1.0-rc.1, ... (pre-release)
             ↓
-        Fix bugs? → Bump rcN, repeat
+        Fix bugs? → Bump rc.N, repeat
             ↓
 main branch (via PR merge)
     ↓
@@ -48,8 +48,8 @@ Auto sync: PR main → develop, auto-merge, delete release branch
 
 | Branch | Purpose | Release Type | Version Format | Who Creates |
 |--------|---------|--------------|----------------|-------------|
-| `develop` | Ongoing development | dev | `X.Y.Z-devN` | team |
-| `release/vX.Y.Z` | Feature freeze, stabilization | rc | `X.Y.Z-rcN` | release engineer |
+| `develop` | Ongoing development | dev | `X.Y.Z-dev.N` | team |
+| `release/vX.Y.Z` | Feature freeze, stabilization | rc | `X.Y.Z-rc.N` | release engineer |
 | `main` | Production-ready | stable | `X.Y.Z` | merge after RC approval |
 
 ---
@@ -59,17 +59,17 @@ Auto sync: PR main → develop, auto-merge, delete release branch
 To bump versions across all components (unified monorepo), use the **`scripts/ci/bump_version.py`** script:
 
 ```bash
-# Dry run (shows what would change, doesn't modify files)
+# Show what would change (displays before/after versions in a table)
 python3 scripts/ci/bump_version.py \
   --repo-root . \
   --part prerelease \
-  --prerelease dev
+  --prerelease-prefix dev
 
 # Actual bump (modifies all pyproject.toml files)
 python3 scripts/ci/bump_version.py \
   --repo-root . \
   --part prerelease \
-  --prerelease dev
+  --prerelease-prefix dev
 ```
 
 **Available parts**:
@@ -77,8 +77,55 @@ python3 scripts/ci/bump_version.py \
 - `minor` - Bump 0.X.0 (0.1.0 → 0.2.0)
 - `patch` - Bump 0.0.X (0.1.0 → 0.1.1)
 - `prerelease` - Bump pre-release version with custom identifier
-  - `--prerelease dev` → `0.1.0-dev0`, `0.1.0-dev1`, etc.
-  - `--prerelease rc` → `0.1.0-rc1`, `0.1.0-rc2`, etc. (default)
+
+**Prerelease bumping**:
+
+Prerelease versions follow the format: `X.Y.Z-{prefix}.{id}` (e.g., `0.1.0-dev.0`, `0.1.0-rc.1`)
+
+```bash
+# Bump to next dev version (0.1.0-dev.0 → 0.1.0-dev.1)
+python3 scripts/ci/bump_version.py \
+  --repo-root . \
+  --part prerelease \
+  --prerelease-prefix dev
+
+# Bump to next rc version (0.1.0-rc.0 → 0.1.0-rc.1)
+python3 scripts/ci/bump_version.py \
+  --repo-root . \
+  --part prerelease \
+  --prerelease-prefix rc
+
+# Change from dev to rc (0.1.0-dev.5 → 0.1.0-rc.0)
+python3 scripts/ci/bump_version.py \
+  --repo-root . \
+  --part prerelease \
+  --prerelease-prefix rc
+```
+
+**Prerelease prefix behavior**:
+- Default prefix: `rc` (used if no prefix specified and no current prerelease exists)
+- **Same prefix**: Increments the ID (`0.1.0-dev.0` → `0.1.0-dev.1`)
+- **Different prefix**: Resets to `.0` (`0.1.0-dev.5` → `0.1.0-rc.0`)
+- **No current prerelease**: Creates new prerelease with `.0` (`0.1.0` → `0.1.0-rc.0`)
+
+**Advanced options**:
+
+```bash
+# Allow downgrading versions (disabled by default)
+# Useful for reverting to earlier prerelease versions
+python3 scripts/ci/bump_version.py \
+  --repo-root . \
+  --part prerelease \
+  --prerelease-prefix dev \
+  --allow-downgrade
+
+# Bump only specific components (defaults to all if not specified)
+python3 scripts/ci/bump_version.py \
+  --repo-root . \
+  --part prerelease \
+  --prerelease-prefix rc \
+  --component packages/shopping-assistant services/shopping-assistant
+```
 
 **After bumping**:
 
@@ -88,8 +135,8 @@ git diff pyproject.toml*
 git diff packages/*/pyproject.toml services/*/pyproject.toml
 
 # Commit with standardized message format
-OLD_VERSION="0.1.0-dev1"
-NEW_VERSION="0.1.0-dev2"
+OLD_VERSION="0.1.0-dev.0"
+NEW_VERSION="0.1.0-dev.1"
 git add pyproject.toml packages/*/pyproject.toml services/*/pyproject.toml
 git commit -m "bump version: ${OLD_VERSION} -> ${NEW_VERSION}"
 ```
@@ -111,16 +158,16 @@ Example: 0.1.0, 1.0.0
 
 ### Release Candidate
 ```
-X.Y.Z-rcN
-Examples: 0.1.0-rc1, 0.1.0-rc2, 0.1.0-rc3
+X.Y.Z-rc.N
+Examples: 0.1.0-rc.0, 0.1.0-rc.1, 0.1.0-rc.2
 ```
 - Pre-release version for testing
-- N starts at 1 and increments per RC
+- N starts at 0 and increments per RC
 
 ### Dev Release
 ```
-X.Y.Z-devN
-Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
+X.Y.Z-dev.N
+Examples: 0.1.0-dev.0, 0.1.0-dev.1, 0.2.0-dev.0
 ```
 - Development pre-release
 - N starts at 0 and increments per dev release
@@ -139,16 +186,16 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 
 1. **Bump version using the bump script**:
    ```bash
-   # Bump to next dev version (0.1.0-dev0 → 0.1.0-dev1)
+   # Bump to next dev version (0.1.0-dev.0 → 0.1.0-dev.1)
    python3 scripts/ci/bump_version.py \
      --repo-root . \
      --part prerelease \
-     --prerelease dev
+     --prerelease-prefix dev
    ```
 
 2. **Add CHANGELOG entries** (optional for dev):
    ```markdown
-   ## [v0.1.0-dev0] (YYYY-MM-DD)
+   ## [v0.1.0-dev.0] (YYYY-MM-DD)
 
    - ... changes
    ```
@@ -156,19 +203,19 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 3. **Commit with standardized format**:
    ```bash
    git add pyproject.toml packages/*/pyproject.toml services/*/pyproject.toml CHANGELOG.md
-   git commit -m "bump version: 0.1.0-dev0 -> 0.1.0-dev1"
+   git commit -m "bump version: 0.1.0-dev.0 -> 0.1.0-dev.1"
    ```
 
 4. **Trigger release workflow**:
    - Go to **Actions** → **Release** → **Run workflow**
    - Select branch: `develop`
    - Workflow will:
-     - Validate version format (`X.Y.Z-devN`)
-     - Create git tag `v0.1.0-dev1`
+     - Validate version format (`X.Y.Z-dev.N`)
+     - Create git tag `v0.1.0-dev.1`
      - **NOT** create a GitHub release (dev releases are internal snapshots)
 
 **Result**:
-- ✅ Git tag: `v0.1.0-dev1`
+- ✅ Git tag: `v0.1.0-dev.1`
 - ✅ GitHub Actions logs
 - ❌ No GitHub Release page
 
@@ -194,16 +241,16 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 
 3. **Bump version to RC0 using the script**:
    ```bash
-   # Bump to rc0 (0.1.0-dev5 → 0.1.0-rc1)
+   # Bump to rc.0 (0.1.0-dev.5 → 0.1.0-rc.0)
    python3 scripts/ci/bump_version.py \
      --repo-root . \
      --part prerelease \
-     --prerelease rc
+     --prerelease-prefix rc
    ```
 
 4. **Update CHANGELOG**:
    ```markdown
-   ## [v0.1.0-rc1] (YYYY-MM-DD)
+   ## [v0.1.0-rc.0] (YYYY-MM-DD)
 
    ### First Release Candidate
    - ... feature list
@@ -212,7 +259,7 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 5. **Commit and push with standardized format**:
    ```bash
    git add pyproject.toml packages/*/pyproject.toml services/*/pyproject.toml CHANGELOG.md
-   git commit -m "bump version: 0.1.0-dev5 -> 0.1.0-rc1"
+   git commit -m "bump version: 0.1.0-dev.5 -> 0.1.0-rc.0"
    git push origin release/v0.1.0
    ```
 
@@ -235,17 +282,17 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
    ```
 
 2. **Version must match branch** (validation enforced):
-   - Branch: `release/v0.1.0` → Version in pyproject.toml: `0.1.0-rc1`, `0.1.0-rc2`, etc.
+   - Branch: `release/v0.1.0` → Version in pyproject.toml: `0.1.0-rc.0`, `0.1.0-rc.1`, etc.
    - ⚠️ Version mismatch will fail validation
 
 3. **Trigger release workflow**:
    - Go to **Actions** → **Release** → **Run workflow**
    - Select branch: `release/v0.1.0`
    - Workflow will:
-     - Validate version format (`X.Y.Z-rcN`)
+     - Validate version format (`X.Y.Z-rc.N`)
      - Validate base version matches branch (`0.1.0`)
-     - Validate CHANGELOG entry for `[v0.1.0-rcN]` exists
-     - Create git tag `v0.1.0-rc1`
+     - Validate CHANGELOG entry for `[v0.1.0-rc.N]` exists
+     - Create git tag `v0.1.0-rc.0`
      - Create GitHub Release (marked as **pre-release**)
 
 **If bugs found**:
@@ -260,32 +307,32 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 
 2. **Bump RC version using the script**:
    ```bash
-   # Bump to next RC (0.1.0-rc1 → 0.1.0-rc2)
+   # Bump to next RC (0.1.0-rc.1 → 0.1.0-rc.2)
    python3 scripts/ci/bump_version.py \
      --repo-root . \
      --part prerelease \
-     --prerelease rc
+     --prerelease-prefix rc
    ```
 
-3. **Update CHANGELOG with new [v0.1.0-rc2] entry**:
+3. **Update CHANGELOG with new [v0.1.0-rc.1] entry**:
    ```markdown
-   ## [v0.1.0-rc2] (YYYY-MM-DD)
+   ## [v0.1.0-rc.1] (YYYY-MM-DD)
 
-   ### Release Candidate 2
-   - Bug fixes from rc1
+   ### Release Candidate 1
+   - Bug fixes from rc.0
    ```
 
 4. **Commit and push with standardized format**:
    ```bash
    git add pyproject.toml packages/*/pyproject.toml services/*/pyproject.toml CHANGELOG.md
-   git commit -m "bump version: 0.1.0-rc1 -> 0.1.0-rc2"
+   git commit -m "bump version: 0.1.0-rc.0 -> 0.1.0-rc.1"
    git push origin release/v0.1.0
    ```
 
-5. **Trigger workflow again** for `v0.1.0-rc2`
+5. **Trigger workflow again** for `v0.1.0-rc.1`
 
 **Result**:
-- ✅ Git tags: `v0.1.0-rc1`, `v0.1.0-rc2`, etc.
+- ✅ Git tags: `v0.1.0-rc.0`, `v0.1.0-rc.1`, etc.
 - ✅ GitHub Releases (pre-release badge)
 - ✅ Release notes extracted from CHANGELOG
 
@@ -298,19 +345,19 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 **Prerequisites**:
 - RC is approved (no more bugs found)
 - Release branch: `release/v0.1.0`
-- Latest RC tag: `v0.1.0-rcN`
+- Latest RC tag: `v0.1.0-rc.N`
 
 **Manual steps**:
 
-1. **Remove RC suffix from version** (0.1.0-rcN → 0.1.0):
+1. **Remove RC suffix from version** (`0.1.0-rc.N` → `0.1.0`):
    ```bash
    git checkout release/v0.1.0
    git pull origin release/v0.1.0
 
    # Option A: Manual edit (simplest for final release)
-   # Edit all pyproject.toml files: 0.1.0-rcN → 0.1.0
+   # Edit all pyproject.toml files: 0.1.0-rc.N → 0.1.0
 
-   # Option B: Use bump script to finalize
+   # Option B: Use bump script with major/minor/patch
    # (This converts the pre-release version to stable)
    # After manual edits or script:
    ```
@@ -327,7 +374,7 @@ Examples: 0.1.0-dev0, 0.1.0-dev1, 0.2.0-dev0
 3. **Commit on release branch with standardized format**:
    ```bash
    git add pyproject.toml packages/*/pyproject.toml services/*/pyproject.toml CHANGELOG.md
-   git commit -m "bump version: 0.1.0-rcN -> 0.1.0"
+   git commit -m "bump version: 0.1.0-rc.N -> 0.1.0"
    git push origin release/v0.1.0
    ```
 
@@ -459,7 +506,7 @@ Uses semver semantics via `semver` library:
 **A**: New version is not greater than latest tag.
 - Check `git tag -l | sort -V | tail -1` (latest tag)
 - Ensure new version in `pyproject.toml` is higher
-- Example: If latest is `v0.1.0-dev5`, next must be `v0.1.0-dev6` or `v0.1.0-rc0` or higher
+- Example: If latest is `v0.1.0-dev.5`, next must be `v0.1.0-dev.6` or `v0.1.0-rc.0` or higher
 
 ### Q: RC branch validation failed
 **A**: Version base doesn't match branch name.
@@ -501,13 +548,13 @@ The workflow enforces these rules (cannot be bypassed):
 
 ### Dev Release (`develop` branch)
 - ✅ Branch must be exactly `develop`
-- ✅ Version format: `X.Y.Z-devN`
+- ✅ Version format: `X.Y.Z-dev.N`
 
 ### RC Release (`release/vX.Y.Z` branch)
 - ✅ Branch must match `release/v*`
-- ✅ Version format: `X.Y.Z-rcN`
+- ✅ Version format: `X.Y.Z-rc.N`
 - ✅ Base version (`X.Y.Z`) must match branch version
-- ✅ CHANGELOG entry required: `[v0.1.0-rcN]`
+- ✅ CHANGELOG entry required: `[v0.1.0-rc.N]`
 
 ### Stable Release (`main` branch)
 - ✅ Branch must be exactly `main`
@@ -529,12 +576,12 @@ graph TD
 
     subgraph release["🟡 Release Branch"]
         R1["release/vX.Y.Z<br/>(created manually)"]
-        R2["Version: X.Y.Z-rc0<br/>(manual edit)"]
+        R2["Version: X.Y.Z-rc.0<br/>(manual edit)"]
         R3["Trigger: workflow_dispatch"]
-        R4["Bug found?<br/>Bump rcN, repeat"]
+        R4["Bug found?<br/>Bump rc.N, repeat"]
         R1 --> R2 --> R3
         R3 -.->|fix bugs| R4
-        R4 -.->|rcN+1| R3
+        R4 -.->|rc.N+1| R3
     end
 
     subgraph main["🟢 Main Branch"]
@@ -569,8 +616,8 @@ graph TD
 
 | Phase | Branch | Version | Trigger | GitHub Release |
 |-------|--------|---------|---------|-----------------|
-| Development | `develop` | `X.Y.Z-devN` | Manual | ❌ No |
-| Stabilization | `release/vX.Y.Z` | `X.Y.Z-rcN` | Manual | ✅ Pre-release |
+| Development | `develop` | `X.Y.Z-dev.N` | Manual | ❌ No |
+| Stabilization | `release/vX.Y.Z` | `X.Y.Z-rc.N` | Manual | ✅ Pre-release |
 | Production | `main` | `X.Y.Z` | Auto (push) | ✅ Stable |
 | Sync | (auto) | (auto) | Auto | (auto) |
 

--- a/packages/shopping-assistant/pyproject.toml
+++ b/packages/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant"
-version = "0.1.0-dev0"
+version = "0.1.0-dev.0"
 
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project"
-version = "0.1.0-dev0"
+version = "0.1.0-dev.0"
 
 requires-python = ">=3.12"
 dependencies = [

--- a/scripts/ci/bump_version.py
+++ b/scripts/ci/bump_version.py
@@ -29,22 +29,56 @@ COMPONENT_FILE_CONFIG = {
 }
 
 ALL_COMPONENTS = list(COMPONENT_FILE_CONFIG.keys())
-SEMVER_PRERELEASE_DEFAULT = "rc"
+SEMVER_PRERELEASE_PREFIX_DEFAULT = "rc"
+
+
+def get_prerelease_prefix(version: semver.Version) -> str:
+    if version.prerelease is None:
+        return ""
+    return version.prerelease.split(".")[0]
 
 
 def bump_part(
-    version: semver.Version, part: str, prerelease: str | None = None
+    version: semver.Version,
+    part: str,
+    prerelease_prefix: str | None = None,
+    allow_downgrade: bool = False,
 ) -> semver.Version:
-    if (
-        (part == "prerelease")
-        and (version.prerelease is None)
-        and (prerelease != SEMVER_PRERELEASE_DEFAULT)
-    ):
-        version_dict = version.to_dict()
-        version_dict["prerelease"] = f"{prerelease}0"
-        next_version = semver.Version(**version_dict)
+    is_prerelease = part == "prerelease"
+
+    if is_prerelease:
+        # does a prerelease tag exist
+        has_prerelease = version.prerelease is not None
+
+        cur_prerelease_prefix = get_prerelease_prefix(version)
+
+        if not prerelease_prefix:
+            if has_prerelease:
+                prerelease_prefix = cur_prerelease_prefix
+            else:
+                prerelease_prefix = SEMVER_PRERELEASE_PREFIX_DEFAULT
+
+        # is provided prerelease prefix same as current one
+        is_same_prerelease = cur_prerelease_prefix == prerelease_prefix
+
+        if has_prerelease and is_same_prerelease:
+            # increment the prerelease number
+            next_version = version.next_version(part="prerelease")
+        elif (has_prerelease and not is_same_prerelease) or (not has_prerelease):
+            # change the prerelease prefix
+            version_dict = version.to_dict()
+            version_dict["prerelease"] = f"{prerelease_prefix}.0"
+            next_version = semver.Version(**version_dict)
     else:
         next_version = version.next_version(part=part)
+
+    if not allow_downgrade and next_version < version:
+        raise ValueError(
+            f"Downgrading version from {version} to {next_version} is not allowed. "
+            "Set allow_downgrade=True to allow downgrading."
+        )
+    if next_version == version:
+        raise ValueError(f"Version {version} did not get bumped.")
 
     return next_version
 
@@ -209,10 +243,15 @@ def main():
         help="Version part to bump",
     )
     parser.add_argument(
-        "--prerelease",
+        "--prerelease-prefix",
         required=False,
-        default=SEMVER_PRERELEASE_DEFAULT,
-        help="Prerelease initialization identifier",
+        default=None,
+        help="Prerelease prefix (e.g., rc, dev)",
+    )
+    parser.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help="Allow downgrading version",
     )
 
     args = parser.parse_args()
@@ -234,7 +273,12 @@ def main():
             )
             old_versions_files[fpath] = {
                 "current": old_version,
-                "new": bump_part(old_version, args.part, args.prerelease),
+                "new": bump_part(
+                    old_version,
+                    args.part,
+                    args.prerelease_prefix,
+                    allow_downgrade=args.allow_downgrade,
+                ),
             }
         versions_components[component] = old_versions_files
 
@@ -263,7 +307,10 @@ def main():
                 new_version=version_info["new"],
             )
 
+    print()
+    print("=" * 80)
     print("Version bumped successfully")
+    print("=" * 80)
 
 
 if __name__ == "__main__":

--- a/services/ecom-backend/pyproject.toml
+++ b/services/ecom-backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecom-backend-service"
-version = "0.1.0-dev0"
+version = "0.1.0-dev.0"
 
 requires-python = ">=3.12"
 

--- a/services/shopping-assistant/pyproject.toml
+++ b/services/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-service"
-version = "0.1.0-dev0"
+version = "0.1.0-dev.0"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
## Summary

This PR standardizes the semantic versioning format across the monorepo to follow SemVer conventions with proper dot notation in prerelease versions (e.g., `0.1.0-dev.0` instead of `0.1.0-dev0`). It also enhances the version bumping script to correctly handle prerelease transitions (dev → rc) and adds comprehensive documentation in `RELEASING.md`.

## Changes

### 1. Version Naming Convention Fix

#### Updated pyproject.toml Files

Fixed version strings across all four component `pyproject.toml` files to use proper SemVer prerelease format with dot notation:

**Before:**
```toml
version = "0.1.0-dev0"
```

**After:**
```toml
version = "0.1.0-dev.0"
```

Files modified:
- `pyproject.toml` (root)
- `packages/shopping-assistant/pyproject.toml`
- `services/shopping-assistant/pyproject.toml`
- `services/ecom-backend/pyproject.toml`

This ensures consistency with semantic versioning standards where prerelease versions follow the format `X.Y.Z-{prefix}.{id}`.

### 2. Enhanced Version Bumping Script

#### Improved `scripts/ci/bump_version.py`

Completely refactored the prerelease bumping logic to handle complex version transitions:

**New Features:**

1. **Smart Prerelease Prefix Handling**: Added `get_prerelease_prefix()` function to extract the prefix from existing prerelease versions:
   ```python
   def get_prerelease_prefix(version: semver.Version) -> str:
       if version.prerelease is None:
           return ""
       return version.prerelease.split(".")[0]
   ```

2. **Intelligent Bumping Logic**: The `bump_part()` function now handles three distinct scenarios:
   - **Same prefix increment**: `0.1.0-dev.0` → `0.1.0-dev.1` (increments ID)
   - **Different prefix transition**: `0.1.0-dev.5` → `0.1.0-rc.0` (changes prefix, resets ID to 0)
   - **New prerelease creation**: `0.1.0` → `0.1.0-rc.0` (creates prerelease from stable)

3. **Allow Downgrade Option**: Added `--allow-downgrade` flag for reverting to earlier prerelease versions when needed

4. **Better Error Handling**: Validates that versions actually changed and prevents accidental downgrades without explicit opt-in

5. **Improved CLI Arguments**:
   - Renamed `--prerelease` to `--prerelease-prefix` for clarity
   - Changed default from hardcoded to `None` (lets logic determine appropriate prefix)
   - Added validation and error messages

6. **Enhanced Output**: Added visual formatting (separator lines) to version bump confirmation message

**Code Logic:**
```python
if is_prerelease:
    has_prerelease = version.prerelease is not None
    cur_prerelease_prefix = get_prerelease_prefix(version)

    # Determine prerelease prefix
    if not prerelease_prefix:
        prerelease_prefix = cur_prerelease_prefix if has_prerelease else SEMVER_PRERELEASE_PREFIX_DEFAULT

    # Compare prefixes and apply appropriate logic
    is_same_prerelease = cur_prerelease_prefix == prerelease_prefix

    if has_prerelease and is_same_prerelease:
        next_version = version.next_version(part="prerelease")
    elif (has_prerelease and not is_same_prerelease) or (not has_prerelease):
        version_dict = version.to_dict()
        version_dict["prerelease"] = f"{prerelease_prefix}.0"
        next_version = semver.Version(**version_dict)
```

### 3. Comprehensive RELEASING.md Documentation

#### Updated Release Process Guide

Substantially enhanced `RELEASING.md` with:

1. **Updated Version Format Examples**: All documentation now reflects the correct dot-notation format:
   - Dev releases: `X.Y.Z-dev.N` (was `X.Y.Z-devN`)
   - RC releases: `X.Y.Z-rc.N` (was `X.Y.Z-rcN`)

2. **New Prerelease Bumping Section**: Added comprehensive guide with concrete examples:
   ```bash
   # Bump to next dev version
   python3 scripts/ci/bump_version.py --repo-root . --part prerelease --prerelease-prefix dev

   # Change from dev to rc (transitions prerelease)
   python3 scripts/ci/bump_version.py --repo-root . --part prerelease --prerelease-prefix rc
   ```

3. **Prerelease Prefix Behavior Documentation**: Clearly explains how the script behaves:
   - Default prefix selection logic
   - Same-prefix increment vs different-prefix transition
   - Prerelease creation from stable versions
   - ID reset behavior when changing prefixes

4. **Advanced Options**: New subsection documenting:
   - `--allow-downgrade` flag usage
   - `--component` flag for selective component bumping
   - Real-world use cases and examples

5. **Updated Examples**: All version examples and workflow examples updated to reflect new format:
   - `0.1.0-dev.0` → `0.1.0-dev.1`
   - `0.1.0-dev.5` → `0.1.0-rc.0` (transition example)

## Benefits

1. **Semantic Versioning Compliance**: The dot-notation format (`0.1.0-dev.0`) is the standard SemVer format for prerelease versions, ensuring compatibility with version comparison tools and package registries (PyPI, etc.)

2. **Flexible Version Transitions**: The enhanced script intelligently handles transitions between dev, rc, and stable versions without manual version arithmetic, reducing release process errors

3. **Clear Documentation**: Comprehensive examples and explanations in `RELEASING.md` enable team members to understand and use the release workflow correctly without script internals knowledge

4. **Production-Ready Bumping**: Added validation to prevent accidental downgrades and ensure versions always progress forward (unless explicitly overridden)

5. **Monorepo Consistency**: All components use the same versioning format and logic, maintaining unified release cadence across packages and services

## Testing

To verify the changes work correctly:

```bash
# Test bump to next dev version
python3 scripts/ci/bump_version.py \
  --repo-root . \
  --part prerelease \
  --prerelease-prefix dev

# Test transition from dev to rc (should reset ID to 0)
python3 scripts/ci/bump_version.py \
  --repo-root . \
  --part prerelease \
  --prerelease-prefix rc

# Test bumping only specific components
python3 scripts/ci/bump_version.py \
  --repo-root . \
  --part prerelease \
  --prerelease-prefix rc \
  --component packages/shopping-assistant

# Verify version format in pyproject.toml files
cat pyproject.toml | grep version
cat packages/shopping-assistant/pyproject.toml | grep version
cat services/shopping-assistant/pyproject.toml | grep version
cat services/ecom-backend/pyproject.toml | grep version

# Check the updated documentation
cat RELEASING.md | grep -A 5 "Prerelease bumping"
```

Expected outcomes:
- All versions display in `X.Y.Z-{prefix}.{id}` format
- Script shows before/after versions in a table
- Different prefix values correctly reset the ID to `.0`
- Same prefix values increment the existing ID
- Documentation clearly explains the versioning scheme