### PR TITLE
[TEST] Release/v0.1.0 - DO NOT MERGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-## [v0.1.0] - TBD
+## [v0.1.0-rc.0] - 2026-03-03
 
 ### 1st Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [v0.1.0-rc.1] - 2026-03-03
+
+Just bumped the version
+
 ## [v0.1.0-rc.0] - 2026-03-03
 
 ### 1st Release

--- a/packages/shopping-assistant/CHANGELOG.md
+++ b/packages/shopping-assistant/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED]
 
 
-## [v0.1.0] - TBD
+## [v0.1.0-rc.0] - 2026-03-03
 
 ## 1st Release
 

--- a/packages/shopping-assistant/pyproject.toml
+++ b/packages/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant"
-version = "0.1.0-dev.0"
+version = "0.1.0-rc.0"
 
 requires-python = ">=3.12"
 

--- a/packages/shopping-assistant/pyproject.toml
+++ b/packages/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project"
-version = "0.1.0-dev.0"
+version = "0.1.0-rc.0"
 
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 
 requires-python = ">=3.12"
 dependencies = [

--- a/services/ecom-backend/CHANGELOG.md
+++ b/services/ecom-backend/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-## [v0.1.0] - TBD
+## [v0.1.0-rc.0] - 2026-03-03
 
 ## 1st Release
 

--- a/services/ecom-backend/pyproject.toml
+++ b/services/ecom-backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecom-backend-service"
-version = "0.1.0-dev.0"
+version = "0.1.0-rc.0"
 
 requires-python = ">=3.12"
 

--- a/services/ecom-backend/pyproject.toml
+++ b/services/ecom-backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecom-backend-service"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 
 requires-python = ">=3.12"
 

--- a/services/shopping-assistant/CHANGELOG.md
+++ b/services/shopping-assistant/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED]
 
 
-## [v0.1.0] - TBD
+## [v0.1.0-rc.0] - 2026-03-03
 
 ## 1st Release
 

--- a/services/shopping-assistant/pyproject.toml
+++ b/services/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-service"
-version = "0.1.0-dev.0"
+version = "0.1.0-rc.0"
 
 requires-python = ">=3.12"
 

--- a/services/shopping-assistant/pyproject.toml
+++ b/services/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-service"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 
 requires-python = ">=3.12"
 


### PR DESCRIPTION
# [TEST] Release/v0.1.0

This is a test for release workflow of rc versions. DO NOT MERGE


## Testing 1st RC version


STEP 1: Bump version to `0.1.0-rc.0` 

```bash

(root@dev) ➜  genai-shopping-assistant git:(release/v0.1.0) python scripts/ci/bump_version.py --repo-root . --part prerelease --prerelease-prefix rc   
Parsing root version
Parsing packages/shopping-assistant version
Parsing services/shopping-assistant version
Parsing services/ecom-backend version

| Component                   | File                                       | Current Version   | New Version   |
|-----------------------------|--------------------------------------------|-------------------|---------------|
| root                        | pyproject.toml                             | 0.1.0-dev.0       | 0.1.0-rc.0    |
| packages/shopping-assistant | packages/shopping-assistant/pyproject.toml | 0.1.0-dev.0       | 0.1.0-rc.0    |
| services/shopping-assistant | services/shopping-assistant/pyproject.toml | 0.1.0-dev.0       | 0.1.0-rc.0    |
| services/ecom-backend       | services/ecom-backend/pyproject.toml       | 0.1.0-dev.0       | 0.1.0-rc.0    |

| Component                   | Status (Current Version)   | Status (New Version)   |
|-----------------------------|----------------------------|------------------------|
| root                        | 0.1.0-dev.0 (OK)           | 0.1.0-rc.0 (OK)        |
| packages/shopping-assistant | 0.1.0-dev.0 (OK)           | 0.1.0-rc.0 (OK)        |
| services/shopping-assistant | 0.1.0-dev.0 (OK)           | 0.1.0-rc.0 (OK)        |
| services/ecom-backend       | 0.1.0-dev.0 (OK)           | 0.1.0-rc.0 (OK)        |

================================================================================
Version bumped successfully
================================================================================
```

STEP 2: Update CHANGELOG.md

```

## [v0.1.0-rc.0] - 2026-03-03
```

STEP 3: Trigger Release workflow

<img width="1266" height="644" alt="image" src="https://github.com/user-attachments/assets/c28aa8ec-9df5-462d-9d6e-2195e0635eb1" />

<img width="1011" height="883" alt="image" src="https://github.com/user-attachments/assets/047f41db-e774-45b0-96ae-378fa819366b" />

## Testing 2nd RC version

STEP 1: Bump version to  `0.1.0-rc.0` 

```bash
(root@dev) ➜  genai-shopping-assistant git:(release/v0.1.0) ✗ python scripts/ci/bump_version.py --repo-root . --part prerelease --prerelease-prefix rc
Parsing root version
Parsing packages/shopping-assistant version
Parsing services/shopping-assistant version
Parsing services/ecom-backend version

| Component                   | File                                       | Current Version   | New Version   |
|-----------------------------|--------------------------------------------|-------------------|---------------|
| root                        | pyproject.toml                             | 0.1.0-rc.0        | 0.1.0-rc.1    |
| packages/shopping-assistant | packages/shopping-assistant/pyproject.toml | 0.1.0-rc.0        | 0.1.0-rc.1    |
| services/shopping-assistant | services/shopping-assistant/pyproject.toml | 0.1.0-rc.0        | 0.1.0-rc.1    |
| services/ecom-backend       | services/ecom-backend/pyproject.toml       | 0.1.0-rc.0        | 0.1.0-rc.1    |

| Component                   | Status (Current Version)   | Status (New Version)   |
|-----------------------------|----------------------------|------------------------|
| root                        | 0.1.0-rc.0 (OK)            | 0.1.0-rc.1 (OK)        |
| packages/shopping-assistant | 0.1.0-rc.0 (OK)            | 0.1.0-rc.1 (OK)        |
| services/shopping-assistant | 0.1.0-rc.0 (OK)            | 0.1.0-rc.1 (OK)        |
| services/ecom-backend       | 0.1.0-rc.0 (OK)            | 0.1.0-rc.1 (OK)        |

================================================================================
Version bumped successfully
================================================================================
```

Running release workflow fails since CHANGELOG is not updated

<img width="1244" height="746" alt="image" src="https://github.com/user-attachments/assets/98cf55c4-96ab-462f-902b-61a7db14e455" />


STEP 2: Update CHANGELOG


```
## [v0.1.0-rc.1] - 2026-03-03

Just bumped the version
```

STEP 3: Trigger Release workflow

<img width="1248" height="476" alt="image" src="https://github.com/user-attachments/assets/de1c1750-5f0b-4fe9-bb6b-d0a7bbab923f" />


<img width="966" height="471" alt="image" src="https://github.com/user-attachments/assets/96408471-38d7-471c-8db1-5d4beeda0ab8" />


STEP 1: Bump version to `0.1.0-rc.0` 

STEP 2: Update CHANGELOG

STEP 3: Merge to `main`

STEP 4: Auto Trigger Release workflow

STEP 5: Merge `main` to `develop`

> NOTE: Keep branch for reference

## Testing Cleanup

Delete Github release + tags

```bash
(root@dev) ➜  genai-shopping-assistant git:(release/v0.1.0) gh release delete v0.1.0-rc.1 --cleanup-tag

? Delete release v0.1.0-rc.1 in abhi8893/genai-shopping-assistant? Yes
✓ Deleted release and tag v0.1.0-rc.1
(root@dev) ➜  genai-shopping-assistant git:(release/v0.1.0) gh release delete v0.1.0-rc.0 --cleanup-tag

? Delete release v0.1.0-rc.0 in abhi8893/genai-shopping-assistant? Yes
✓ Deleted release and tag v0.1.0-rc.0
```

## Final Release (NOT DONE HERE)

STEP 1: Bump version to `0.1.0-rc.0` 

STEP 2: Update CHANGELOG

STEP 3: Merge to `main`

STEP 4: Auto Trigger Release workflow

STEP 5: Merge `main` to `develop`

> NOTE: Keep branch for reference
