### PR TITLE
dev: add make target to delete gone branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,3 +297,19 @@ direnv-setup:
 	@echo "✓ .envrc files created and allowed"
 
 
+
+show-gone-branches:
+	@if [ "$(DELETE)" == "TRUE" ]; then \
+		echo "Deleting gone branches..."; \
+		for branch in $$(git for-each-ref --format '%(refname) %(upstream:track)' refs/heads | awk -v delete=TRUE '$$2 == "[gone]" {sub("refs/heads/", "", $$1); print $$1}'); do \
+			echo "Deleting branch $$branch..."; \
+			git branch -D $$branch; \
+		done; \
+		echo ""; \
+		echo "✓ Gone branches deleted"; \
+	else \
+		echo "Listing gone branches...\n"; \
+		git for-each-ref --format '%(refname) %(upstream:track)' refs/heads | awk '$$2 == "[gone]" {sub("refs/heads/", "", $$1); print "- " $$1}'; \
+		echo ""; \
+		echo "Run 'make show-gone-branches DELETE=TRUE' to delete these branches"; \
+	fi


### PR DESCRIPTION
# Description

```bash
$ make show-gone-branches                      
Listing gone branches...

- dev/add-release-workflow
- dev/enhance-venv-management
- fix/misc-release-workflow
- release/v0.1.0

Run 'make show-gone-branches DELETE=TRUE' to delete these branches
```

```bash
$ make show-gone-branches DELETE=TRUE
Deleting gone branches...
Deleting branch dev/add-release-workflow...
Deleted branch dev/add-release-workflow (was 4c65027).
Deleting branch dev/enhance-venv-management...
Deleted branch dev/enhance-venv-management (was bcc59b7).
Deleting branch fix/misc-release-workflow...
Deleted branch fix/misc-release-workflow (was 08c1bc6).
Deleting branch release/v0.1.0...
Deleted branch release/v0.1.0 (was 2c81cdf).

✓ Gone branches deleted
```