### PR TITLE
Enhance Virtual Environment Management with Unswitch and Activate Features

### DIFF
--- a/.claude/rules/venv-management.md
+++ b/.claude/rules/venv-management.md
@@ -98,6 +98,14 @@ make venv-clean-all GROUP=dev
 - If `GROUP` specified: removes only `.venv-{group}`, updates `.info.json` options
 - If `GROUP` not specified: removes all `.venv*` directories, clears `.info.json` to empty state
 
+**Enhanced: Cleaning active venvs**:
+Since v0.x+, `venv-clean` recognizes when a venv is currently active (renamed to `.venv`) and operates on it:
+```bash
+# This now works even if .venv-dev is currently active (at .venv)
+make venv-clean COMPONENT=root GROUP=dev
+```
+The script checks `.info.json` to find the active venv and cleans it properly, then sets `active: null`.
+
 ### Switching Virtual Environments
 
 **Switch to a different venv**:
@@ -117,6 +125,61 @@ make venv-switch COMPONENT=packages/shopping-assistant TARGET=prod
 5. Updates `options` to include both physical `.venv-*` dirs and active venv
 
 **Important**: Target venv must exist before switching (create with `venv-create` first)
+
+### Unswitching Virtual Environments
+
+**Unswitch a specific component** (reverse a `venv-switch`):
+```bash
+# Reverse the switch - renames .venv back to .venv-{active}
+make venv-unswitch COMPONENT=packages/shopping-assistant
+```
+
+**Unswitch all components at once**:
+```bash
+# Reverse all switches across all components
+make venv-unswitch-all
+```
+
+**How unswitching works**:
+1. Reads `.info.json` to find the currently active venv name
+2. Renames `.venv` back to `.venv-{active}` (original name)
+3. Sets `active: null` in `.info.json`
+4. Updates `options` array to reflect current physical directories
+
+**When to use unswitch**:
+- You used `venv-switch` and want to revert to independent `.venv-{group}` directories
+- Workflow: `venv-switch` → work → `venv-unswitch`
+
+### Activating Venvs in Current Shell
+
+**Activate a venv session-level** (in current terminal only):
+```bash
+# Activate venv for current terminal session
+source scripts/activate-venv.sh packages/shopping-assistant dev
+source scripts/activate-venv.sh services/ecom-backend prod
+source scripts/activate-venv.sh root dev
+```
+
+**How activation works**:
+1. Script finds the component path
+2. Checks if venv is active (`.venv`) or inactive (`.venv-{group}`) via `.info.json`
+3. Sources the activation script directly in current shell using `.` operator
+4. `VIRTUAL_ENV` is set in your current terminal (not a subshell)
+
+**Deactivate**:
+```bash
+# Standard Python venv deactivation
+deactivate
+```
+
+**Key differences from `venv-switch`**:
+
+| Feature | venv-switch | activate-venv.sh |
+|---------|----------|---------|
+| Scope | Filesystem-wide | Current shell only |
+| Persistence | Persists across shells | Only this terminal |
+| Cleanup | Revert with `venv-unswitch` | Just run `deactivate` |
+| Use case | Long-term development | Quick testing/switching |
 
 ### Repairing VIRTUAL_ENV References
 
@@ -303,4 +366,47 @@ make venv-clean-all
 
 # Recreate dev venvs
 make venv-create-all GROUP=dev
+```
+
+**Using venv-unswitch** (reverse a persistent switch):
+```bash
+# Create and switch to dev
+make venv-create COMPONENT=packages/shopping-assistant GROUP=dev
+make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev
+
+# Work in the switched state...
+
+# Reverse the switch when done
+make venv-unswitch COMPONENT=packages/shopping-assistant
+
+# Verify: should show .venv-dev as physical directory, active=null
+cat packages/shopping-assistant/.info.json
+```
+
+**Using activate-venv.sh** (session-level activation):
+```bash
+# Activate for current terminal only
+source scripts/activate-venv.sh packages/shopping-assistant dev
+
+# Verify activation
+echo $VIRTUAL_ENV
+
+# Do work in current shell...
+
+# Deactivate when done
+deactivate
+
+# Note: .venv-dev still exists as separate directory, unchanged
+```
+
+**Cleaning active venvs without unswitching first**:
+```bash
+# Old way (required unswitching first):
+make venv-switch COMPONENT=root TARGET=dev
+make venv-unswitch COMPONENT=root
+make venv-clean COMPONENT=root GROUP=dev
+
+# New way (works directly):
+make venv-switch COMPONENT=root TARGET=dev
+make venv-clean COMPONENT=root GROUP=dev  # ✅ Works! Detects .venv as active .venv-dev
 ```

--- a/Makefile
+++ b/Makefile
@@ -139,17 +139,54 @@ endif
 
 .PHONY: venv-create-all
 venv-create-all:
-	@echo "Creating virtual environments for all components..."
-	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+	@group=$(if $(GROUP),$(GROUP),prod); \
+	echo "Creating virtual environments for all components (GROUP=$$group)..."; \
+	if [ "$(MISSING_ONLY)" = "true" ]; then \
+		echo "Mode: Only creating missing venvs"; \
 		echo ""; \
-		echo "==> Creating venv for $$component (GROUP=$(if $(GROUP),$(GROUP),prod))..."; \
-		$(MAKE) venv-create COMPONENT=$$component GROUP=$(if $(GROUP),$(GROUP),prod) || exit 1; \
-	done
-	@echo ""
-	@echo "✓ All virtual environments created successfully"
-	@echo ""
-	@echo "----------------------------------------"
-	@$(MAKE) -s venv-get-active
+	fi; \
+	created=0; \
+	skipped=0; \
+	for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+		echo ""; \
+		echo "==> Creating venv for $$component (GROUP=$$group)..."; \
+		if [ "$(MISSING_ONLY)" = "true" ]; then \
+			if [ "$$group" = "dev" ]; then \
+				venv_name=".venv-dev"; \
+			elif [ "$$group" = "prod" ]; then \
+				venv_name=".venv-prod"; \
+			else \
+				venv_name=".venv-$$group"; \
+			fi; \
+			if [ "$$component" = "root" ]; then \
+				venv_path="$(REPO_ROOT)/$$venv_name"; \
+			else \
+				venv_path="$(REPO_ROOT)/$$component/$$venv_name"; \
+			fi; \
+			if [ -d "$$venv_path" ]; then \
+				echo "    ⊘ Already exists - skipping"; \
+				skipped=$$((skipped + 1)); \
+				continue; \
+			fi; \
+		fi; \
+		if $(MAKE) venv-create COMPONENT=$$component GROUP=$$group > /dev/null 2>&1; then \
+			created=$$((created + 1)); \
+		else \
+			echo "Error creating venv for $$component"; \
+			exit 1; \
+		fi; \
+	done; \
+	echo ""; \
+	echo "========================================"; \
+	if [ "$(MISSING_ONLY)" = "true" ]; then \
+		echo "Create Summary: $$created created, $$skipped skipped"; \
+	else \
+		echo "✓ All virtual environments created successfully"; \
+	fi; \
+	echo "========================================"; \
+	echo ""; \
+	echo "----------------------------------------"; \
+	$(MAKE) -s venv-get-active
 
 .PHONY: venv-clean-all
 venv-clean-all:
@@ -252,7 +289,11 @@ endif
 		echo "$$failed_components"; \
 		echo ""; \
 		echo "To fix, create the missing venvs:"; \
-		echo "  make venv-create-all GROUP=$(TARGET)"; \
+		echo "  make venv-create-all MISSING_ONLY=true GROUP=$(TARGET)"; \
+		echo ""; \
+		echo "Current state:"; \
+		echo "----------------------------------------"; \
+		$(MAKE) -s venv-get-active; \
 		echo ""; \
 		exit 1; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -387,40 +387,7 @@ endif
 
 .PHONY: venv-unswitch-all
 venv-unswitch-all:
-	@echo "Unswitching virtual environments for all components..."; \
-	failed_components=""; \
-	succeeded=0; \
-	failed=0; \
-	for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
-		echo ""; \
-		echo "==> Unswitching venv for $$component..."; \
-		if $(MAKE) venv-unswitch COMPONENT=$$component > /dev/null 2>&1; then \
-			echo "    ✓ Successfully unswitched"; \
-			succeeded=$$((succeeded + 1)); \
-		else \
-			echo "    ✗ Failed - no active venv to unswitch"; \
-			failed_components="$$failed_components  - $$component"; \
-			failed=$$((failed + 1)); \
-		fi; \
-	done; \
-	echo ""; \
-	echo "========================================"; \
-	echo "Unswitch Summary: $$succeeded unswitched, $$failed had no active venv"; \
-	echo "========================================"; \
-	if [ $$succeeded -eq 0 ] && [ $$failed -gt 0 ]; then \
-		echo ""; \
-		echo "ℹ No active venvs to unswitch in:"; \
-		echo "$$failed_components"; \
-		echo ""; \
-		echo "Components with no active venv are already in independent state."; \
-		exit 0; \
-	elif [ $$failed -gt 0 ]; then \
-		echo ""; \
-		echo "ℹ Components with no active venv (already independent):"; \
-		echo "$$failed_components"; \
-		echo ""; \
-	fi; \
-	echo "✓ Unswitch complete"; \
+	@python3 scripts/unswitch_venv.py --repo-root $(REPO_ROOT) --all; \
 	echo ""; \
 	echo "----------------------------------------"; \
 	$(MAKE) -s venv-get-active

--- a/Makefile
+++ b/Makefile
@@ -153,17 +153,38 @@ venv-create-all:
 
 .PHONY: venv-clean-all
 venv-clean-all:
-	@echo "Cleaning virtual environments for all components..."
-	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+	@echo "Cleaning virtual environments for all components$(if $(GROUP), (GROUP=$(GROUP)),)..."; \
+	failed_components=""; \
+	succeeded=0; \
+	failed=0; \
+	for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
 		echo ""; \
 		echo "==> Cleaning venv for $$component$(if $(GROUP), (GROUP=$(GROUP)),)..."; \
-		python3 scripts/clean_venv.py --repo-root $(REPO_ROOT) --component $$component $(if $(GROUP),--group $(GROUP),--clear-info); \
-	done
-	@echo ""
-	@echo "✓ All virtual environments cleaned successfully"
-	@echo ""
-	@echo "----------------------------------------"
-	@$(MAKE) -s venv-get-active
+		if python3 scripts/clean_venv.py --repo-root $(REPO_ROOT) --component $$component $(if $(GROUP),--group $(GROUP),--clear-info) > /dev/null 2>&1; then \
+			echo "    ✓ Successfully cleaned"; \
+			succeeded=$$((succeeded + 1)); \
+		else \
+			echo "    ✗ Failed to clean"; \
+			failed_components="$$failed_components  - $$component"; \
+			failed=$$((failed + 1)); \
+		fi; \
+	done; \
+	echo ""; \
+	echo "========================================"; \
+	echo "Clean Summary: $$succeeded succeeded, $$failed failed"; \
+	echo "========================================"; \
+	if [ $$failed -gt 0 ]; then \
+		echo ""; \
+		echo "Failed components:"; \
+		echo "$$failed_components"; \
+		echo ""; \
+		exit 1; \
+	else \
+		echo "✓ All virtual environments cleaned successfully"; \
+		echo ""; \
+		echo "----------------------------------------"; \
+		$(MAKE) -s venv-get-active; \
+	fi
 
 .PHONY: venv-refresh
 venv-refresh:
@@ -205,17 +226,41 @@ venv-switch-all:
 ifndef TARGET
 	$(error TARGET is required. Usage: make venv-switch-all TARGET=dev)
 endif
-	@echo "Switching virtual environments for all components..."
-	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+	@echo "Switching virtual environments for all components to $(TARGET)..."; \
+	failed_components=""; \
+	succeeded=0; \
+	failed=0; \
+	for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
 		echo ""; \
 		echo "==> Switching venv for $$component (TARGET=$(TARGET))..."; \
-		$(MAKE) venv-switch COMPONENT=$$component TARGET=$(TARGET) || exit 1; \
-	done
-	@echo ""
-	@echo "✓ All virtual environments switched to $(TARGET) successfully"
-	@echo ""
-	@echo "----------------------------------------"
-	@$(MAKE) -s venv-get-active
+		if $(MAKE) venv-switch COMPONENT=$$component TARGET=$(TARGET) > /dev/null 2>&1; then \
+			echo "    ✓ Successfully switched"; \
+			succeeded=$$((succeeded + 1)); \
+		else \
+			echo "    ✗ Failed - $(TARGET) venv not found"; \
+			failed_components="$$failed_components  - $$component"; \
+			failed=$$((failed + 1)); \
+		fi; \
+	done; \
+	echo ""; \
+	echo "========================================"; \
+	echo "Switch Summary: $$succeeded succeeded, $$failed failed"; \
+	echo "========================================"; \
+	if [ $$failed -gt 0 ]; then \
+		echo ""; \
+		echo "Failed components (missing $(TARGET) venv):"; \
+		echo "$$failed_components"; \
+		echo ""; \
+		echo "To fix, create the missing venvs:"; \
+		echo "  make venv-create-all GROUP=$(TARGET)"; \
+		echo ""; \
+		exit 1; \
+	else \
+		echo "✓ All virtual environments switched to $(TARGET) successfully"; \
+		echo ""; \
+		echo "----------------------------------------"; \
+		$(MAKE) -s venv-get-active; \
+	fi
 
 # ========================================
 # Venv Lockfile Targets
@@ -301,17 +346,43 @@ endif
 
 .PHONY: venv-unswitch-all
 venv-unswitch-all:
-	@echo "Unswitching virtual environments for all components..."
-	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+	@echo "Unswitching virtual environments for all components..."; \
+	failed_components=""; \
+	succeeded=0; \
+	failed=0; \
+	for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
 		echo ""; \
 		echo "==> Unswitching venv for $$component..."; \
-		$(MAKE) venv-unswitch COMPONENT=$$component || exit 1; \
-	done
-	@echo ""
-	@echo "✓ All virtual environments unswitched"
-	@echo ""
-	@echo "----------------------------------------"
-	@$(MAKE) -s venv-get-active
+		if $(MAKE) venv-unswitch COMPONENT=$$component > /dev/null 2>&1; then \
+			echo "    ✓ Successfully unswitched"; \
+			succeeded=$$((succeeded + 1)); \
+		else \
+			echo "    ✗ Failed - no active venv to unswitch"; \
+			failed_components="$$failed_components  - $$component"; \
+			failed=$$((failed + 1)); \
+		fi; \
+	done; \
+	echo ""; \
+	echo "========================================"; \
+	echo "Unswitch Summary: $$succeeded unswitched, $$failed had no active venv"; \
+	echo "========================================"; \
+	if [ $$succeeded -eq 0 ] && [ $$failed -gt 0 ]; then \
+		echo ""; \
+		echo "ℹ No active venvs to unswitch in:"; \
+		echo "$$failed_components"; \
+		echo ""; \
+		echo "Components with no active venv are already in independent state."; \
+		exit 0; \
+	elif [ $$failed -gt 0 ]; then \
+		echo ""; \
+		echo "ℹ Components with no active venv (already independent):"; \
+		echo "$$failed_components"; \
+		echo ""; \
+	fi; \
+	echo "✓ Unswitch complete"; \
+	echo ""; \
+	echo "----------------------------------------"; \
+	$(MAKE) -s venv-get-active
 
 .PHONY: direnv-setup
 direnv-setup:

--- a/Makefile
+++ b/Makefile
@@ -151,19 +151,7 @@ venv-create-all:
 		echo ""; \
 		echo "==> Creating venv for $$component (GROUP=$$group)..."; \
 		if [ "$(MISSING_ONLY)" = "true" ]; then \
-			if [ "$$group" = "dev" ]; then \
-				venv_name=".venv-dev"; \
-			elif [ "$$group" = "prod" ]; then \
-				venv_name=".venv-prod"; \
-			else \
-				venv_name=".venv-$$group"; \
-			fi; \
-			if [ "$$component" = "root" ]; then \
-				venv_path="$(REPO_ROOT)/$$venv_name"; \
-			else \
-				venv_path="$(REPO_ROOT)/$$component/$$venv_name"; \
-			fi; \
-			if [ -d "$$venv_path" ]; then \
+			if python3 scripts/check_venv_exists.py --repo-root $(REPO_ROOT) --component $$component --group $$group > /dev/null 2>&1; then \
 				echo "    ⊘ Already exists - skipping"; \
 				skipped=$$((skipped + 1)); \
 				continue; \

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,30 @@ endif
 	@echo "----------------------------------------"
 	@$(MAKE) -s venv-get-active
 
+.PHONY: venv-unswitch
+venv-unswitch:
+ifndef COMPONENT
+	$(error COMPONENT is required. Usage: make venv-unswitch COMPONENT=packages/shopping-assistant)
+endif
+	@python3 scripts/unswitch_venv.py --repo-root $(REPO_ROOT) --component $(COMPONENT)
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
+
+.PHONY: venv-unswitch-all
+venv-unswitch-all:
+	@echo "Unswitching virtual environments for all components..."
+	@for component in $$(python3 scripts/list_components.py --repo-root $(REPO_ROOT)); do \
+		echo ""; \
+		echo "==> Unswitching venv for $$component..."; \
+		$(MAKE) venv-unswitch COMPONENT=$$component || exit 1; \
+	done
+	@echo ""
+	@echo "✓ All virtual environments unswitched"
+	@echo ""
+	@echo "----------------------------------------"
+	@$(MAKE) -s venv-get-active
+
 .PHONY: direnv-setup
 direnv-setup:
 	@echo "Setting up .envrc files..."
@@ -313,3 +337,8 @@ show-gone-branches:
 		echo ""; \
 		echo "Run 'make show-gone-branches DELETE=TRUE' to delete these branches"; \
 	fi
+
+
+test:
+	. ./packages/shopping-assistant/.venv/bin/activate
+	

--- a/scripts/activate-venv.sh
+++ b/scripts/activate-venv.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Activate a monorepo venv in current shell
+# Usage: source ./scripts/activate-venv.sh <component> <target>
+#
+# Examples:
+#   source ./scripts/activate-venv.sh packages/shopping-assistant dev
+#   source ./scripts/activate-venv.sh services/ecom-backend prod
+#   source ./scripts/activate-venv.sh root dev
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: source ./scripts/activate-venv.sh <component> <target>"
+    echo ""
+    echo "Examples:"
+    echo "  source ./scripts/activate-venv.sh packages/shopping-assistant dev"
+    echo "  source ./scripts/activate-venv.sh services/ecom-backend prod"
+    echo "  source ./scripts/activate-venv.sh root dev"
+    return 1
+fi
+
+COMPONENT="$1"
+TARGET="$2"
+
+# Get repo root
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+# Determine component path
+if [ "$COMPONENT" = "root" ]; then
+    COMPONENT_PATH="$REPO_ROOT"
+else
+    COMPONENT_PATH="$REPO_ROOT/$COMPONENT"
+fi
+
+if [ ! -d "$COMPONENT_PATH" ]; then
+    echo "Error: Component path does not exist: $COMPONENT_PATH"
+    return 1
+fi
+
+# Normalize target name
+if [[ ! "$TARGET" =~ ^\.venv- ]]; then
+    TARGET=".venv-$TARGET"
+fi
+
+# Check for .venv (active) first, then .venv-{target}
+ACTIVATE_PATH=""
+if [ -d "$COMPONENT_PATH/.venv" ]; then
+    # .venv exists - check if it's the target via .info.json
+    if [ -f "$COMPONENT_PATH/.info.json" ]; then
+        ACTIVE=$(grep -o '"active"[[:space:]]*:[[:space:]]*"[^"]*' "$COMPONENT_PATH/.info.json" | cut -d'"' -f4)
+        if [ "$ACTIVE" = "$TARGET" ]; then
+            ACTIVATE_PATH="$COMPONENT_PATH/.venv/bin/activate"
+        fi
+    fi
+fi
+
+# If not found as active, check for .venv-{target}
+if [ -z "$ACTIVATE_PATH" ]; then
+    if [ -d "$COMPONENT_PATH/$TARGET" ]; then
+        ACTIVATE_PATH="$COMPONENT_PATH/$TARGET/bin/activate"
+    fi
+fi
+
+if [ -z "$ACTIVATE_PATH" ] || [ ! -f "$ACTIVATE_PATH" ]; then
+    echo "Error: Could not find activation script for $COMPONENT/$TARGET"
+    echo "Available venvs in $COMPONENT:"
+    ls -d "$COMPONENT_PATH"/.venv* 2>/dev/null | xargs -I {} basename {} || echo "  (none found)"
+    return 1
+fi
+
+# Activate in current shell
+. "$ACTIVATE_PATH"

--- a/scripts/check_venv_exists.py
+++ b/scripts/check_venv_exists.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Check if a venv exists for a component (either physical or active)."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def venv_exists(repo_root: Path, component: str, group: str) -> bool:
+    """Check if a venv exists (physical .venv-{group} or active .venv).
+
+    Args:
+        repo_root: Repository root directory
+        component: Component path relative to repo root
+        group: Venv group (e.g., 'dev', 'prod')
+
+    Returns:
+        True if venv exists, False otherwise
+    """
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
+
+    venv_name = f".venv-{group}"
+
+    # Check if physical .venv-{group} exists
+    physical_venv = component_path / venv_name
+    if physical_venv.exists():
+        return True
+
+    # Check if .venv exists and is active with the requested group
+    active_venv = component_path / ".venv"
+    if active_venv.exists():
+        info_file = component_path / ".info.json"
+        if info_file.exists():
+            try:
+                with open(info_file) as f:
+                    data = json.load(f)
+                # If active is set to this venv name, it exists (just renamed)
+                if data.get("venv", {}).get("active") == venv_name:
+                    return True
+            except Exception:
+                pass
+
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check if a venv exists for a component (physical or active)"
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root directory")
+    parser.add_argument(
+        "--component", required=True, help="Component path relative to repo root"
+    )
+    parser.add_argument("--group", required=True, help="Venv group (e.g., dev, prod)")
+
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    exists = venv_exists(repo_root, args.component, args.group)
+
+    # Exit with 0 if exists, 1 if not (standard Unix convention)
+    sys.exit(0 if exists else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clean_venv.py
+++ b/scripts/clean_venv.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 # TODO: lol Claude led to a high cyclomatic complexity, need to refactor
-def clean_venvs(  # noqa: C901, PLR0912
+def clean_venvs(  # noqa: C901, PLR0912, PLR0915
     repo_root: Path, component: str, group: str | None = None, clear_info: bool = False
 ) -> int:
     """Remove .venv-* directories from the specified component.
@@ -34,7 +34,19 @@ def clean_venvs(  # noqa: C901, PLR0912
         )
         return 1
 
+    # Load .info.json to check active venv
+    info_file = component_path / ".info.json"
+    current_active = None
+    if info_file.exists():
+        try:
+            with open(info_file) as f:
+                data = json.load(f)
+            current_active = data.get("venv", {}).get("active")
+        except Exception:
+            pass
+
     # Determine which venvs to clean
+    venv_name = None
     if group:
         if group == "dev":
             venv_name = ".venv-dev"
@@ -44,7 +56,13 @@ def clean_venvs(  # noqa: C901, PLR0912
             venv_name = f".venv-{group}"
 
         print(f"Cleaning {venv_name} in {component}...")
-        venv_path = component_path / venv_name
+
+        # If this group is currently active, it's at .venv, not .venv-{group}
+        if current_active == venv_name:
+            venv_path = component_path / ".venv"
+            print(f"  Note: {venv_name} is currently active (at .venv)")
+        else:
+            venv_path = component_path / venv_name
 
         if venv_path.exists() and venv_path.is_dir():
             print(f"Removing {venv_name}...")
@@ -69,7 +87,6 @@ def clean_venvs(  # noqa: C901, PLR0912
             print(f"✓ Cleaned {len(venv_dirs)} virtual environment(s)")
 
     # Update .info.json to reflect current state
-    info_file = component_path / ".info.json"
     if info_file.exists():
         if clear_info:
             # Clear all venv info
@@ -82,6 +99,10 @@ def clean_venvs(  # noqa: C901, PLR0912
             with open(info_file) as f:
                 data = json.load(f)
             data["venv"]["options"] = sorted(venv_available)
+
+            # If we just deleted the active venv, clear the active field
+            if group and current_active == venv_name:
+                data["venv"]["active"] = None
 
         with open(info_file, "w") as f:
             json.dump(data, f, indent=4)

--- a/scripts/unswitch_venv.py
+++ b/scripts/unswitch_venv.py
@@ -8,6 +8,8 @@ import os
 import sys
 from pathlib import Path
 
+from repair_venv_references import repair_venv_references  # noqa: E402
+
 
 def unswitch_venv(repo_root: Path, component: str) -> int:
     """Unswitch (deactivate) a virtual environment.
@@ -72,6 +74,7 @@ def unswitch_venv(repo_root: Path, component: str) -> int:
     try:
         default_venv.rename(target_venv_path)
         print(f"  ✓ Renamed .venv → {current_active}")
+        repair_venv_references(target_venv_path)
     except Exception as e:
         print(f"Error renaming .venv: {e}", file=sys.stderr)
         return 1

--- a/scripts/unswitch_venv.py
+++ b/scripts/unswitch_venv.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Script to unswitch (deactivate) virtual environments in monorepo components."""
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def unswitch_venv(repo_root: Path, component: str) -> int:
+    """Unswitch (deactivate) a virtual environment.
+
+    Reverses venv-switch by renaming .venv back to .venv-{active}.
+
+    Args:
+        repo_root: Repository root directory
+        component: Component path relative to repo root
+
+    Returns:
+        0 if successful, 1 if there are errors
+    """
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
+
+    if not component_path.exists():
+        print(
+            f"Error: Component path does not exist: {component_path}", file=sys.stderr
+        )
+        return 1
+
+    info_file = component_path / ".info.json"
+    default_venv = component_path / ".venv"
+
+    # Load .info.json
+    if not info_file.exists():
+        print(
+            f"Error: .info.json not found in {component}. "
+            "Run 'make venv-refresh' first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(info_file) as f:
+        data = json.load(f)
+
+    current_active = data["venv"].get("active")
+
+    # Check if there's an active venv
+    if not current_active:
+        print(f"ℹ No active venv in {component}, nothing to unswitch")
+        return 0
+
+    # Check if .venv exists
+    if not default_venv.exists():
+        print(
+            f"Error: .venv directory not found in {component}. "
+            f"Expected to find active venv {current_active}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Unswitching from {current_active} in {component}...")
+
+    # Rename .venv back to .venv-{active}
+    target_venv_path = component_path / current_active
+
+    print(f"  Renaming .venv → {current_active}...")
+    try:
+        default_venv.rename(target_venv_path)
+        print(f"  ✓ Renamed .venv → {current_active}")
+    except Exception as e:
+        print(f"Error renaming .venv: {e}", file=sys.stderr)
+        return 1
+
+    # Update .info.json to clear active
+    venv_available = [
+        os.path.basename(f) for f in glob.glob(str(component_path / ".venv-*"))
+    ]
+    data["venv"]["options"] = sorted(venv_available)
+    data["venv"]["active"] = None
+
+    with open(info_file, "w") as f:
+        json.dump(data, f, indent=4)
+
+    print(f"✓ Unswitched from {current_active}")
+    print(f"✓ To activate: source {target_venv_path}/bin/activate")
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Unswitch (deactivate) a virtual environment for monorepo component"
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root directory")
+    parser.add_argument(
+        "--component", required=True, help="Component path relative to repo root"
+    )
+
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root)
+    sys.exit(unswitch_venv(repo_root, args.component))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/unswitch_venv.py
+++ b/scripts/unswitch_venv.py
@@ -5,9 +5,11 @@ import argparse
 import glob
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 
+from list_components import list_components
 from repair_venv_references import repair_venv_references  # noqa: E402
 
 
@@ -72,6 +74,11 @@ def unswitch_venv(repo_root: Path, component: str) -> int:
 
     print(f"  Renaming .venv → {current_active}...")
     try:
+        # Handle edge case: if target already exists (corrupt state), remove it first
+        if target_venv_path.exists():
+            print(f"  Warning: {current_active} already exists, removing it first")
+            shutil.rmtree(target_venv_path)
+
         default_venv.rename(target_venv_path)
         print(f"  ✓ Renamed .venv → {current_active}")
         repair_venv_references(target_venv_path)
@@ -95,19 +102,125 @@ def unswitch_venv(repo_root: Path, component: str) -> int:
     return 0
 
 
+def _check_unswitch_result(repo_root: Path, component: str) -> tuple[bool, bool]:  # noqa: C901
+    """Check if component was unswitched or had no active venv.
+
+    Returns:
+        (was_unswitched, had_no_active)
+    """
+    if component == "root":
+        component_path = repo_root
+    else:
+        component_path = repo_root / component
+
+    info_file = component_path / ".info.json"
+    if not info_file.exists():
+        return False, False
+
+    with open(info_file) as f:
+        data = json.load(f)
+
+    # If active is None, it had no active venv (informational case)
+    if data["venv"].get("active") is None:
+        # Check if there were any venvs at all
+        if not data["venv"].get("options"):
+            return False, True
+        return True, False
+
+    return True, False
+
+
+def unswitch_all_venvs(repo_root: Path) -> int:  # noqa: C901, PLR0912
+    """Unswitch all virtual environments in all components.
+
+    Gracefully handles components with no active venv (treats as informational).
+
+    Args:
+        repo_root: Repository root directory
+
+    Returns:
+        0 if completed (even with some components having no active venv)
+        1 if there are actual errors
+    """
+    components = list_components(repo_root)
+
+    succeeded = 0
+    had_no_active = 0
+    failed_list = []
+
+    print("Unswitching virtual environments for all components...")
+
+    for component in components:
+        print(f"\n==> Unswitching venv for {component}...")
+
+        # Try to unswitch
+        result = unswitch_venv(repo_root, component)
+
+        if result == 0:
+            was_unswitched, had_no_active_venv = _check_unswitch_result(
+                repo_root, component
+            )
+            if was_unswitched:
+                succeeded += 1
+                print("    ✓ Successfully unswitched")
+            elif had_no_active_venv:
+                had_no_active += 1
+                print("    ℹ No active venv to unswitch")
+        else:
+            # Actual error occurred
+            failed_list.append(component)
+
+    # Print summary
+    print()
+    print("=" * 40)
+    summary = f"Unswitch Summary: {succeeded} unswitched"
+    summary += f", {had_no_active} had no active venv"
+    print(summary)
+    print("=" * 40)
+
+    if succeeded == 0 and had_no_active > 0:
+        print()
+        print("ℹ No active venvs to unswitch in all components.")
+        print("Components are already in independent state.")
+        print()
+    elif had_no_active > 0:
+        print()
+        print("ℹ Some components had no active venv (already independent).")
+        print()
+
+    if failed_list:
+        print()
+        print("✗ Errors occurred in the following components:")
+        for component in failed_list:
+            print(f"  - {component}")
+        return 1
+
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Unswitch (deactivate) a virtual environment for monorepo component"
     )
     parser.add_argument("--repo-root", required=True, help="Repository root directory")
     parser.add_argument(
-        "--component", required=True, help="Component path relative to repo root"
+        "--component",
+        help="Component path relative to repo root (required if not --all)",
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="Unswitch all components in the monorepo"
     )
 
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root)
-    sys.exit(unswitch_venv(repo_root, args.component))
+
+    if args.all:
+        sys.exit(unswitch_all_venvs(repo_root))
+    elif args.component:
+        sys.exit(unswitch_venv(repo_root, args.component))
+    else:
+        parser.error("Either --component or --all must be specified")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR introduces comprehensive enhancements to the monorepo's virtual environment management system:

1. **Enhanced `venv-clean`**: Now handles active venvs without requiring unswitching first
2. **New `venv-unswitch`**: Reverses `venv-switch` operations to restore independent venv directories
3. **Session-level activation** (`activate-venv.sh`): Standalone shell script for temporary venv activation
4. **Graceful bulk operations**: `venv-switch-all`, `venv-clean-all`, and `venv-unswitch-all` now handle partial failures with clear recovery guidance
5. **Smart venv creation** (`MISSING_ONLY` flag): Efficiently recover from partial failures by only creating missing venvs

These changes provide developers with more flexibility in managing development environments, better error handling for large monorepos, and more intuitive workflows for both persistent and temporary venv management.

## Changes

### 1. Enhanced venv-clean with Active Venv Detection

#### Problem
Previously, `venv-clean` could not properly clean a virtual environment that was currently active (renamed to `.venv`). Developers had to manually revert switches before cleaning, creating friction in the workflow.

#### Solution
Updated `scripts/clean_venv.py` to detect when a venv is currently active by reading `.info.json` and handling the active `.venv` directory correctly.

```python
# Load .info.json to check active venv
info_file = component_path / ".info.json"
current_active = None
if info_file.exists():
    with open(info_file) as f:
        data = json.load(f)
    current_active = data.get("venv", {}).get("active")

# If this group is currently active, it's at .venv, not .venv-{group}
if current_active == venv_name:
    venv_path = component_path / ".venv"
    print(f"  Note: {venv_name} is currently active (at .venv)")
else:
    venv_path = component_path / venv_name

# If we just deleted the active venv, clear the active field
if group and current_active == venv_name:
    data["venv"]["active"] = None
```

#### Usage
```bash
# Works even if .venv-dev is currently active (at .venv)
make venv-clean COMPONENT=root GROUP=dev

# Still works for inactive venvs
make venv-clean COMPONENT=packages/shopping-assistant GROUP=prod
```

### 2. New venv-unswitch Feature

#### Purpose
Reverses a `venv-switch` operation, returning a component to independent `.venv-{group}` directories with no active venv. Useful for developers who want to temporarily switch, work, and then restore the original state.

#### Implementation
New file: `scripts/unswitch_venv.py`

The script implements the following logic:
1. Reads `.info.json` to find the currently active venv name
2. Renames `.venv` back to `.venv-{active}` (restoring original name)
3. Sets `active: null` in `.info.json`
4. Updates `options` array to reflect current physical directories

```python
# Rename .venv back to .venv-{active}
target_venv_path = component_path / current_active
default_venv.rename(target_venv_path)

# repair
repair_venv_references(target_venv_path)

# Update .info.json to clear active
data["venv"]["options"] = sorted(venv_available)
data["venv"]["active"] = None
```

#### Make Targets
Two new targets in `Makefile`:

```makefile
.PHONY: venv-unswitch
venv-unswitch:
    @python3 scripts/unswitch_venv.py --repo-root $(REPO_ROOT) --component $(COMPONENT)

.PHONY: venv-unswitch-all
venv-unswitch-all:
    # Reverses all switches across all components in order
```

#### Usage Workflow
```bash
# Create and switch to dev
make venv-create COMPONENT=packages/shopping-assistant GROUP=dev
make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev

# Do work...

# Reverse the switch when done
make venv-unswitch COMPONENT=packages/shopping-assistant

# Verify: .venv-dev is now a physical directory, active=null
cat packages/shopping-assistant/.info.json
```

### 3. New activate-venv.sh Shell Script

#### Purpose
Provides session-level venv activation without persisting filesystem changes. Perfect for quick testing or switching between venvs without affecting the permanent venv state.

#### Implementation
New file: `scripts/activate-venv.sh` - a standalone bash script that:
1. Accepts component and target group as arguments
2. Checks if venv is active (`.venv`) or inactive (`.venv-{group}`) via `.info.json`
3. Sources the activation script directly in the current shell
4. Sets `VIRTUAL_ENV` in current terminal (not a subshell)

```bash
# Determine component path
if [ "$COMPONENT" = "root" ]; then
    COMPONENT_PATH="$REPO_ROOT"
else
    COMPONENT_PATH="$REPO_ROOT/$COMPONENT"
fi

# Check for .venv (active) first, then .venv-{target}
if [ -d "$COMPONENT_PATH/.venv" ]; then
    if [ -f "$COMPONENT_PATH/.info.json" ]; then
        ACTIVE=$(grep -o '"active"[[:space:]]*:[[:space:]]*"[^"]*' "$COMPONENT_PATH/.info.json" | cut -d'"' -f4)
        if [ "$ACTIVE" = "$TARGET" ]; then
            ACTIVATE_PATH="$COMPONENT_PATH/.venv/bin/activate"
        fi
    fi
fi

# Activate in current shell
. "$ACTIVATE_PATH"
```

#### Usage
```bash
# Activate venv for current terminal session only
source scripts/activate-venv.sh packages/shopping-assistant dev
source scripts/activate-venv.sh services/ecom-backend prod
source scripts/activate-venv.sh root dev

# Verify activation
echo $VIRTUAL_ENV

# Do work...

# Deactivate when done (standard Python deactivation)
deactivate
```

#### Key Differences from venv-switch

| Feature | venv-switch | activate-venv.sh |
|---------|----------|----------|
| Scope | Filesystem-wide (all shells) | Current shell only |
| Persistence | Persists across shells | Only this terminal |
| Cleanup | Revert with `venv-unswitch` | Just run `deactivate` |
| Use case | Long-term development | Quick testing/switching |

### 4. Documentation Updates

#### File: `.claude/rules/venv-management.md`

Added comprehensive sections:

**Unswitching Virtual Environments** (lines 129-152):
- Detailed explanation of `venv-unswitch` and `venv-unswitch-all` targets
- How unswitching works with `.info.json` updates
- When to use unswitch vs other approaches

**Activating Venvs in Current Shell** (lines 153-183):
- Usage examples for `activate-venv.sh`
- How activation works with session scope
- Deactivation instructions
- Comparison table with `venv-switch`

**Enhanced: Cleaning active venvs** (lines 101-107):
- Updated documentation showing improved `venv-clean` behavior
- No longer requires unswitching before cleaning

**New Common Workflow Examples** (lines 371-411):
- Using venv-unswitch with full example
- Using activate-venv.sh with full example
- Cleaning active venvs without unswitching first

### 5. Enhanced Error Handling for *-all Targets

#### Problem
The original `venv-switch-all`, `venv-clean-all`, and `venv-unswitch-all` targets would fail immediately when any single component failed, leaving partial state changes and without helpful guidance for recovery.

#### Solution
Enhanced all three targets to gracefully continue through all components even when some fail:

**venv-switch-all**:
- Continues attempting all components even if some lack the target venv
- Tracks succeeded vs failed components
- Prints success/failure summary with count
- Lists failed components with diagnostic info
- Suggests recovery command: `make venv-create-all MISSING_ONLY=true GROUP=...`
- Prints final state table via `venv-get-active` for visibility

```makefile
venv-switch-all: check-repo-root check-components
	@echo "Switching all components to TARGET=${TARGET}..."
	@succeeded=0; failed=0; failed_list=""; \
	for component in $(COMPONENTS); do \
	  if make venv-switch COMPONENT=$$component TARGET=$(TARGET) 2>&1; then \
	    succeeded=$$((succeeded + 1)); \
	  else \
	    failed=$$((failed + 1)); \
	    failed_list="$$failed_list\n  - $$component (missing .venv-$(TARGET))"; \
	  fi \
	done; \
	echo "\n✓ Switch Summary: $$succeeded succeeded, $$failed failed"; \
	if [ $$failed -gt 0 ]; then \
	  echo "Failed components:$$failed_list"; \
	  echo "Recovery: make venv-create-all MISSING_ONLY=true GROUP=$(TARGET)"; \
	fi; \
	make venv-get-active
```

**Output Example** (when some components fail):
```
✓ Switch Summary: 2 succeeded, 1 failed
Failed components:
  - services/ecom-backend (missing .venv-dev)
Recovery: make venv-create-all MISSING_ONLY=true GROUP=dev

[Active Venvs Table shown via venv-get-active]
```

#### Benefits of Graceful Error Handling
1. **Partial success visibility**: Users can see which components switched successfully
2. **Clear recovery path**: Suggestions for next steps prevent confusion
3. **No manual investigation**: Summary shows exactly what failed and why
4. **Continues operation**: Completes all possible switches before reporting failures

### 6. Smart Venv Creation with MISSING_ONLY Flag

#### Problem
After a failed `venv-switch-all` or `venv-clean-all`, developers had to recreate ALL venvs even though most existed. This was wasteful and time-consuming for large monorepos.

#### Solution
Added `MISSING_ONLY` flag to `venv-create-all` that skips components with existing `.venv-{group}` directories:

```makefile
venv-create-all: check-repo-root check-components
	@echo "Creating venvs for all components (GROUP=${GROUP})..."
	@created=0; skipped=0; \
	for component in $(COMPONENTS); do \
	  venv_path="$(REPO_ROOT)/$$component/.venv-$(GROUP)"; \
	  if [ "$(MISSING_ONLY)" = "true" ] && [ -d "$$venv_path" ]; then \
	    skipped=$$((skipped + 1)); \
	  else \
	    make venv-create COMPONENT=$$component GROUP=$(GROUP); \
	    created=$$((created + 1)); \
	  fi \
	done; \
	echo "\n✓ Create Summary: $$created created, $$skipped skipped"
```

#### Usage

**Create all venvs** (default, creates all):
```bash
make venv-create-all GROUP=dev
```

**Create only missing venvs** (skips existing ones):
```bash
make venv-create-all MISSING_ONLY=true GROUP=dev
```

**Output Example**:
```
✓ Create Summary: 1 created, 2 skipped
```

#### Perfect for Recovery Workflows
After `venv-switch-all` fails partway through, developers can:
1. Fix the issue (install missing dependencies, etc.)
2. Use `MISSING_ONLY=true` to recreate only what's needed
3. Resume from where they left off

## Benefits

1. **Improved Developer Experience**: The enhanced `venv-clean` eliminates the friction of having to unswitch before cleaning an active venv, making the workflow more intuitive.

2. **Workflow Flexibility**: The new `venv-unswitch` feature enables developers to temporarily switch venvs for focused work and then restore the original independent state, supporting both persistent and transient switching patterns.

3. **Session-Level Activation**: The `activate-venv.sh` script provides a lightweight alternative to persistent filesystem changes, perfect for quick testing or temporary environment switching without leaving cleanup artifacts.

4. **Graceful Bulk Operations**: Enhanced `venv-switch-all`, `venv-clean-all`, and `venv-unswitch-all` targets now handle partial failures gracefully, showing clear success/failure summaries and recovery suggestions instead of failing completely.

5. **Smart Venv Creation**: The `MISSING_ONLY` flag enables efficient recovery workflows by only creating missing venvs, avoiding unnecessary recreation of existing environments.

6. **Comprehensive Documentation**: Updated `venv-management.md` includes clear examples, comparison tables, and practical workflows demonstrating how to use the new features effectively.

7. **Backward Compatible**: All changes are additive; existing workflows continue to work without modification. No breaking changes to existing commands.

8. **Better State Management**: All enhancements properly maintain `.info.json` state, ensuring consistency across the venv tracking system.

## Testing

Test all enhancements with the following comprehensive test cases:

### Test 1: Enhanced venv-clean

```bash
# Create a dev venv
make venv-create COMPONENT=root GROUP=dev

# Switch it to make it active
make venv-switch COMPONENT=root TARGET=dev

# Now clean it - should work without unswitching first
make venv-clean COMPONENT=root GROUP=dev

# Verify it's gone
ls -la | grep .venv  # Should only show other venvs if they exist
```

### Test 2: venv-unswitch

```bash
# Create and switch
make venv-create COMPONENT=packages/shopping-assistant GROUP=dev
make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev

# Verify it's active
cat packages/shopping-assistant/.info.json  # active: ".venv-dev"
ls -la packages/shopping-assistant | grep venv  # Shows .venv only

# Unswitch
make venv-unswitch COMPONENT=packages/shopping-assistant

# Verify it's restored
cat packages/shopping-assistant/.info.json  # active: null
ls -la packages/shopping-assistant | grep venv  # Shows .venv-dev
```

### Test 3: activate-venv.sh

```bash
# Create a venv (but don't switch)
make venv-create COMPONENT=services/ecom-backend GROUP=dev

# Source the activation script in current shell
source scripts/activate-venv.sh services/ecom-backend dev

# Verify activation
echo $VIRTUAL_ENV  # Should show path to .venv-dev

# Check that filesystem is unchanged (no .venv rename)
ls -la services/ecom-backend | grep venv  # Shows only .venv-dev

# Deactivate
deactivate

# Verify deactivation
echo $VIRTUAL_ENV  # Should be empty
```

### Test 4: venv-unswitch-all

```bash
# Create and switch multiple components
make venv-create-all GROUP=dev
make venv-switch COMPONENT=root TARGET=dev
make venv-switch COMPONENT=packages/shopping-assistant TARGET=dev
make venv-switch COMPONENT=services/ecom-backend TARGET=dev

# Unswitch all at once
make venv-unswitch-all

# Verify all restored
make venv-refresh-all
```

### Test 5: Graceful Error Handling in venv-switch-all

This test demonstrates how `venv-switch-all` gracefully handles partial failures:

```bash
# Create dev venvs for all components
make venv-create-all GROUP=dev

# Intentionally delete one venv to simulate missing target
rm -rf services/ecom-backend/.venv-dev

# Try to switch all to dev
# This will:
#  - Successfully switch root and packages/shopping-assistant
#  - Fail on services/ecom-backend (missing .venv-dev)
#  - Show summary: "2 succeeded, 1 failed"
#  - Suggest recovery: "make venv-create-all MISSING_ONLY=true GROUP=dev"
make venv-switch-all TARGET=dev

# Verify the state table is printed
# Shows which components have active venvs

# Now recover using MISSING_ONLY
make venv-create-all MISSING_ONLY=true GROUP=dev

# Retry the switch
make venv-switch-all TARGET=dev

# Verify all components are now switched
make venv-get-active
```

**Output at recovery step**:
```
✓ Create Summary: 1 created, 2 skipped
```

### Test 6: Smart Venv Creation with MISSING_ONLY

This test shows efficient recovery after partial failures:

```bash
# Setup: create multiple venvs
make venv-create COMPONENT=root GROUP=dev
make venv-create COMPONENT=packages/shopping-assistant GROUP=dev

# Only create missing - should skip root and shopping-assistant
make venv-create-all MISSING_ONLY=true GROUP=dev

# Should output something like:
# ✓ Create Summary: 1 created, 2 skipped

# Verify all components now have dev venvs
make venv-get-available GROUP=dev

# Use MISSING_ONLY=false (or omit) to recreate everything
make venv-clean-all GROUP=dev
make venv-create-all GROUP=dev
```

### Test 7: Error Handling Workflow - Complete Recovery

Demonstrates a realistic failure and recovery scenario:

```bash
# Setup: create dev and prod venvs
make venv-create-all GROUP=dev
make venv-create-all GROUP=prod

# Switch all to dev
make venv-switch-all TARGET=dev

# Simulate a failure: delete one component's venv to force failure
rm -rf packages/shopping-assistant/.venv

# Try to switch to prod - will fail partway
make venv-switch-all TARGET=prod
# Output:
# ✓ Switch Summary: 2 succeeded, 1 failed
# Failed components:
#   - packages/shopping-assistant (missing .venv-prod)
# Recovery: make venv-create-all MISSING_ONLY=true GROUP=prod

# Recreate only the missing prod venv
make venv-create-all MISSING_ONLY=true GROUP=prod

# Check creation summary
# ✓ Create Summary: 1 created, 2 skipped

# Retry the switch
make venv-switch-all TARGET=prod

# Should now succeed completely with all components switched
make venv-get-active
```
