### PR TITLE
fix: run all tests if branch is develop, main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
           # check if commit message starts with [include-slow-tests]
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
-          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] || [[ "${{ github.ref_name }}" = "develop" ]] || [[ "${{ github.ref_name }}" = "main" ]] || [[ "${{ github.ref_name }}" = "fix/develop-ci-tests-bug" ]]; then
+          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] || [[ "${{ github.ref_name }}" = "develop" ]] || [[ "${{ github.ref_name }}" = "main" ]]; then
             echo "Running all tests including slow ones"
             pytest
             echo "${status_var}=ALL" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,11 @@ jobs:
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
           if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]]; then
             echo "Running all tests including slow ones"
+            echo "TEST_STATUS_${{ matrix.package }}=ALL" >> "$GITHUB_OUTPUT"
             pytest
           else
             echo "Running tests excluding slow ones"
+            echo "TEST_STATUS_${{ matrix.package }}=PARTIAL" >> "$GITHUB_OUTPUT"
             pytest -m "not slow"
           fi
 
@@ -171,12 +173,28 @@ jobs:
     steps:
       - name: Check if all tests were run (and passed)
         run: |
-          # TODO: Make this generic enough to not rely on commit message at two places to
-          #       identify if all or partial tests were run
-          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]]; then
-            echo "All tests were run (including slow ones)"
-            exit 0
-          else
-            echo "All tests were not run: slow tests were excluded. Failing the workflow."
-            exit 1
+
+          PACKAGES=("shopping-assistant" "dummy-pkg")
+
+          for pkg in "${PACKAGES[@]}"; do
+              pkg_var=${pkg//-/_}                     # shopping-assistant -> shopping_assistant
+              status_var="TEST_STATUS_${pkg_var}"     # TEST_STATUS_shopping_assistant
+
+              echo "$status_var: ${!status_var}"
+
+              fail_count=0
+
+              if [[ "${!status_var}" == "ALL" ]]; then
+                  echo "All tests were run for $pkg"
+              else
+                  echo "Not all tests were run for $pkg"
+                  ((fail_count++))
+              fi
+          done
+
+          if [ $fail_count -gt 0 ]; then
+              echo "Some packages failed to run all tests"
+              exit 1
           fi
+
+          echo "Fail count: $fail_count"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,12 @@ jobs:
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
           if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]]; then
             echo "Running all tests including slow ones"
-            echo "TEST_STATUS_${{ matrix.package }}=ALL" >> "$GITHUB_OUTPUT"
+
+            pkg="${{ matrix.package }}"
+            pkg_var="${pkg//-/_}" 
+            status_var="TEST_STATUS_${pkg_var}" 
+            
+            echo "${status_var}=ALL" >> "$GITHUB_OUTPUT"
             pytest
           else
             echo "Running tests excluding slow ones"
@@ -178,7 +183,7 @@ jobs:
 
           for pkg in "${PACKAGES[@]}"; do
               pkg_var="${pkg//-/_}"                     # shopping-assistant -> shopping_assistant
-              status_var="TEST_STATUS_${pkg_var}"     # TEST_STATUS_shopping_assistant
+              status_var="TEST_STATUS_${pkg_var}"       # TEST_STATUS_shopping_assistant
 
               echo "$status_var: ${!status_var}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,11 +173,11 @@ jobs:
 
           pkg="${{ matrix.package }}"
           pkg_var="${pkg//-/_}" 
-          status_var="TEST_STATUS_${pkg_var}" 
+          status_var="TEST_STATUS" 
 
           # check if commit message starts with [include-slow-tests]
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
-          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]]; then
+          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]] && [[ "${{ github.ref_name }}" != "fix/develop-ci-tests-bug" ]]; then
             echo "Running all tests including slow ones"
             pytest
             echo "${status_var}=ALL" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,12 +125,23 @@ jobs:
     needs: [validate_version, build_packages]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: ["shopping-assistant", "dummy-pkg"]
     steps:
       # TODO: Avoid checking out code if wheel can contain "tests" folder
+      # TODO: Perhaps test with build in one matrix is better. 
+      #       The tests step could just add test report as artifact which could be downloaded
+      #       separately to tag as ALL or PARTIAL
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install "${{ env.PYTHON_VERSION }}"
+
       
       - name: Download package artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: Remove dummy-pkg before release
-        package: ["shopping-assistant", "dummy-pkg"]
-    
+        package: ["shopping-assistant", "dummy-pkg"] 
     runs-on: ubuntu-latest
 
     steps:
@@ -106,15 +105,38 @@ jobs:
           mkdir dist
           uv build "packages/${{ matrix.package }}" --out-dir dist
 
-
           WHEEL_FILE=$(ls dist/*.whl)
           SDIST_FILE=$(ls dist/*.tar.gz)
 
-          echo "Found wheel file: $WHEEL_FILE"
-          echo "Found sdist file: $SDIST_FILE"
+          echo "Created wheel file: $WHEEL_FILE"
+          echo "Created sdist file: $SDIST_FILE"
 
           echo "WHEEL_FILE=$WHEEL_FILE" >> "$GITHUB_ENV"
           echo "SDIST_FILE=$SDIST_FILE" >> "$GITHUB_ENV"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.package }}-${{ needs.validate_version.outputs.version }}
+          path: dist/
+
+
+  test_packages:
+    needs: [validate_version, build_packages]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ["shopping-assistant", "dummy-pkg"]
+    steps:
+      # TODO: Avoid checking out code if wheel can contain "tests" folder
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.package }}-${{ needs.validate_version.outputs.version }}
+          path: dist/
 
       - name: Setup test environment
         run: |
@@ -126,34 +148,44 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
 
+          WHEEL_FILE=$(ls dist/*.whl)
+          SDIST_FILE=$(ls dist/*.tar.gz)
+
+          echo "Found wheel file: $WHEEL_FILE"
+          echo "Found sdist file: $SDIST_FILE"
+
           # force re-install built wheel file (to avoid running tests against local imports)
           uv pip install "$WHEEL_FILE" --force-reinstall --python "packages/${{ matrix.package }}/.venv"
           cd packages/${{ matrix.package }}
 
           source .venv/bin/activate
 
+          pkg="${{ matrix.package }}"
+          pkg_var="${pkg//-/_}" 
+          status_var="TEST_STATUS_${pkg_var}" 
+
           # check if commit message starts with [include-slow-tests]
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
           if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]]; then
             echo "Running all tests including slow ones"
-
-            pkg="${{ matrix.package }}"
-            pkg_var="${pkg//-/_}" 
-            status_var="TEST_STATUS_${pkg_var}" 
-            
-            echo "${status_var}=ALL" >> "$GITHUB_OUTPUT"
             pytest
+            echo "${status_var}=ALL" >> "$GITHUB_ENV"
           else
             echo "Running tests excluding slow ones"
-            echo "TEST_STATUS_${{ matrix.package }}=PARTIAL" >> "$GITHUB_OUTPUT"
             pytest -m "not slow"
+            echo "${status_var}=PARTIAL" >> "$GITHUB_ENV"
           fi
 
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.package }}-${{ needs.validate_version.outputs.version }}
-          path: dist/
+      - name: Test status (ALL or PARTIAL)
+        run: |
+          
+          if [ "${{ env.TEST_STATUS }}" = "ALL" ]; then
+            echo "All tests passed"
+            exit 0
+          else
+            echo "Partial tests passed"
+            exit 1
+          fi
 
 
   upload_packages:
@@ -170,36 +202,36 @@ jobs:
           name: all-packages-${{ needs.validate_version.outputs.version }}
           path: dist/
 
-  all_checks_pass_gate:
-    needs: [upload_packages]
-    runs-on: ubuntu-latest
-    env:
-      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-    steps:
-      - name: Check if all tests were run (and passed)
-        run: |
+  # all_checks_pass_gate:
+  #   needs: [upload_packages]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+  #   steps:
+  #     - name: Check if all tests were run (and passed)
+  #       run: |
 
-          PACKAGES=("shopping-assistant" "dummy-pkg")
+  #         PACKAGES=("shopping-assistant" "dummy-pkg")
 
-          for pkg in "${PACKAGES[@]}"; do
-              pkg_var="${pkg//-/_}"                     # shopping-assistant -> shopping_assistant
-              status_var="TEST_STATUS_${pkg_var}"       # TEST_STATUS_shopping_assistant
+  #         for pkg in "${PACKAGES[@]}"; do
+  #             pkg_var="${pkg//-/_}"                     # shopping-assistant -> shopping_assistant
+  #             status_var="TEST_STATUS_${pkg_var}"       # TEST_STATUS_shopping_assistant
 
-              echo "$status_var: ${!status_var}"
+  #             echo "$status_var: ${!status_var}"
 
-              fail_count=0
+  #             fail_count=0
 
-              if [[ "${!status_var}" == "ALL" ]]; then
-                  echo "All tests were run for $pkg"
-              else
-                  echo "Not all tests were run for $pkg"
-                  ((fail_count++))
-              fi
-          done
+  #             if [[ "${!status_var}" == "ALL" ]]; then
+  #                 echo "All tests were run for $pkg"
+  #             else
+  #                 echo "Not all tests were run for $pkg"
+  #                 ((fail_count++))
+  #             fi
+  #         done
 
-          if [ "$fail_count" -gt 0 ]; then
-              echo "Some packages failed to run all tests"
-              exit 1
-          fi
+  #         if [ "$fail_count" -gt 0 ]; then
+  #             echo "Some packages failed to run all tests"
+  #             exit 1
+  #         fi
 
-          echo "Fail count: $fail_count"
+  #         echo "Fail count: $fail_count"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,8 @@ jobs:
           source .venv/bin/activate
 
           # check if commit message starts with [include-slow-tests]
-          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]]; then
+          # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
+          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]]; then
             echo "Running all tests including slow ones"
             pytest
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -220,7 +220,7 @@ jobs:
     if: always()
     steps:
       - name: Check for any failures
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
         run: |
           echo "One or more jobs failed or were cancelled."
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,36 +213,14 @@ jobs:
           name: all-packages-${{ needs.validate_version.outputs.version }}
           path: dist/
 
-  # all_checks_pass_gate:
-  #   needs: [upload_packages]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-  #   steps:
-  #     - name: Check if all tests were run (and passed)
-  #       run: |
-
-  #         PACKAGES=("shopping-assistant" "dummy-pkg")
-
-  #         for pkg in "${PACKAGES[@]}"; do
-  #             pkg_var="${pkg//-/_}"                     # shopping-assistant -> shopping_assistant
-  #             status_var="TEST_STATUS_${pkg_var}"       # TEST_STATUS_shopping_assistant
-
-  #             echo "$status_var: ${!status_var}"
-
-  #             fail_count=0
-
-  #             if [[ "${!status_var}" == "ALL" ]]; then
-  #                 echo "All tests were run for $pkg"
-  #             else
-  #                 echo "Not all tests were run for $pkg"
-  #                 ((fail_count++))
-  #             fi
-  #         done
-
-  #         if [ "$fail_count" -gt 0 ]; then
-  #             echo "Some packages failed to run all tests"
-  #             exit 1
-  #         fi
-
-  #         echo "Fail count: $fail_count"
+  
+  final_status:
+    runs-on: ubuntu-latest
+    needs: [test_packages]
+    if: always()
+    steps:
+      - name: Check for any failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more jobs failed or were cancelled."
+          exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
 
           # check if commit message starts with [include-slow-tests]
           # Always run all tests if the branch is in [develop, main, fix/develop-ci-tests-bug]
-          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] && [[ "${{ github.ref_name }}" != "develop" ]] && [[ "${{ github.ref_name }}" != "main" ]] && [[ "${{ github.ref_name }}" != "fix/develop-ci-tests-bug" ]]; then
+          if [[ "$COMMIT_MESSAGE" == "[include-slow-tests]"* ]] || [[ "${{ github.ref_name }}" = "develop" ]] || [[ "${{ github.ref_name }}" = "main" ]] || [[ "${{ github.ref_name }}" = "fix/develop-ci-tests-bug" ]]; then
             echo "Running all tests including slow ones"
             pytest
             echo "${status_var}=ALL" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           PACKAGES=("shopping-assistant" "dummy-pkg")
 
           for pkg in "${PACKAGES[@]}"; do
-              pkg_var=${pkg//-/_}                     # shopping-assistant -> shopping_assistant
+              pkg_var="${pkg//-/_}"                     # shopping-assistant -> shopping_assistant
               status_var="TEST_STATUS_${pkg_var}"     # TEST_STATUS_shopping_assistant
 
               echo "$status_var: ${!status_var}"
@@ -192,7 +192,7 @@ jobs:
               fi
           done
 
-          if [ $fail_count -gt 0 ]; then
+          if [ "$fail_count" -gt 0 ]; then
               echo "Some packages failed to run all tests"
               exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,8 +171,8 @@ jobs:
 
           source .venv/bin/activate
 
-          pkg="${{ matrix.package }}"
-          pkg_var="${pkg//-/_}" 
+          # pkg="${{ matrix.package }}"
+          # pkg_var="${pkg//-/_}" 
           status_var="TEST_STATUS" 
 
           # check if commit message starts with [include-slow-tests]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -458,20 +458,25 @@ git push origin --delete release/v0.1.0
 |-----|---------|---------|
 | `run_checks` | all branches | Code quality checks (linting, formatting, security) |
 | `validate_version` | all branches | Version validation and consistency checks |
-| `build_packages` | all branches (matrix) | Build and test packages (wheels, sdists) for each component |
+| `build_packages` | all branches (matrix) | Build packages (wheels, sdists) for each component |
+| `test_packages` | all branches (after build) | Test built packages against the wheel artifact |
 | `upload_packages` | all branches | Collect and upload all package artifacts |
-| `all_checks_pass_gate` | all branches | Gate: Ensures all tests were run (blocks PRs if slow tests skipped) |
+| `final_status` | all branches | Gate: Fails if test_packages had failures (blocks PRs if slow tests skipped) |
 
-**Testing in `build_packages` Job**:
-- After building a wheel, packages are tested against the built wheel (not editable install)
+**Testing in `test_packages` Job**:
+- Runs after packages are built
+- Downloads built wheel artifact and tests against it (not editable install)
 - **By default**: Runs `pytest -m "not slow"` (excludes slow tests)
 - **With `[include-slow-tests]` commit message**: Runs all tests including slow ones
   - Prefix the commit message: `[include-slow-tests] <message>`
   - Example: `git commit -m "[include-slow-tests] bump version: 0.1.0-dev.0 -> 0.1.0-dev.1"`
+  - Also enabled on `develop`, `main`, and `fix/develop-ci-tests-bug` branches
 - Tests are run in a dedicated test venv (`.venv-test`)
+- **Fails if partial tests are run**: The job exits with code 1 if slow tests are skipped (PARTIAL), blocking the PR
 
 **Slow Test Marker**:
-Tests marked with `@pytest.mark.slow` are skipped on every push by default, but included in:
+Tests marked with `@pytest.mark.slow` are skipped on most branches by default, but included in:
+- Main workflow on `develop`, `main`, and `fix/develop-ci-tests-bug` branches (always run all tests)
 - Release workflow (manual RC releases with `skip_slow_tests=FALSE`)
 - Release workflow (automated stable releases)
 
@@ -682,15 +687,15 @@ All must have the **same version** (unified releasing).
    - Go to Releases → latest release
    - Download `.whl` and `.tar.gz` files
 
-### Q: PR is blocked — "All tests were not run: slow tests were excluded"
-**A**: The `all_checks_pass_gate` job requires slow tests to be run on main branch pushes.
+### Q: PR is blocked — "One or more jobs failed or were cancelled"
+**A**: The `final_status` job failed because `test_packages` ran with only partial tests (slow tests skipped).
 - This ensures all changes are thoroughly tested before merging to main
 - **Solution**: Redo the commit with `[include-slow-tests]` prefix
   ```bash
   git commit --amend -m "[include-slow-tests] <original message>"
   git push origin <branch> --force-with-lease
   ```
-- Or merge to release branch instead of main (release branches don't have this gate)
+- Or if you're on `develop`, `main`, or `fix/develop-ci-tests-bug`, the tests should run automatically (all tests included)
 
 ### Q: Release workflow failed — "Upstream workflow status: failure"
 **A**: The Main workflow must pass before the Release workflow can proceed.
@@ -766,10 +771,11 @@ graph TD
         MW1["Code Quality Checks"]
         MW2["Validate Version"]
         MW3["Build Packages<br/>(matrix job)"]
-        MW4["Test Packages<br/>(pytest)<br/>Default: skip slow<br/>With [include-slow-tests]: all tests"]
-        MW5["Gate: all_checks_pass_gate<br/>(blocks PRs if slow tests skipped)"]
-        MW6["Upload Artifacts<br/>all-packages-{version}"]
-        MW1 --> MW2 --> MW3 --> MW4 --> MW5 --> MW6
+        MW4["Test Packages<br/>(matrix job, after build)<br/>Default: skip slow<br/>With [include-slow-tests]: all tests<br/>develop/main/fix/*: always all tests"]
+        MW5["Upload Artifacts<br/>all-packages-{version}"]
+        MW6["final_status Gate<br/>(fails if test_packages<br/>had partial test runs)"]
+        MW1 --> MW2 --> MW3 --> MW4 --> MW5
+        MW4 --> MW6
     end
 
     subgraph main["🟢 Main Branch"]

--- a/packages/dummy-pkg/tests/test_example.py
+++ b/packages/dummy-pkg/tests/test_example.py
@@ -29,5 +29,5 @@ def test_small():
 
 @pytest.mark.slow
 def test_long_running():
-    time.sleep(5)
+    time.sleep(0.1)
     assert True

--- a/packages/shopping-assistant/tests/test_example.py
+++ b/packages/shopping-assistant/tests/test_example.py
@@ -29,5 +29,5 @@ def test_small():
 
 @pytest.mark.slow
 def test_long_running():
-    time.sleep(5)
+    time.sleep(0.1)
     assert True


### PR DESCRIPTION
# Description

## Bug

Since merge commit doesn't mention `[include-slow-tests]`, the develop CI did not run all tests failing the `all_checks_pass_gate`

## Changes
- [x] Refactor `test_packages` out of `build_packages`
- [x] Fail `test_packages` if partial tests are run
- [x] Added a `final_status` job 

## Claude Code Doc

```markdown
# Goal

- Refresh previous understanding of release workflow by reading `RELEASING.md`
    - This file hasn't been updated with recent changes from this branch
- Update `RELEASING.md` with current state of release workflow
    - See github actions CI files
    - Compare and contrast the change
- Then update `RELEASING.md` with recent changes to release workfow for package builds in CI.
- Finally, update the mermaid diagram in `RELEASING.md`


# Changes

The following tasks were done:

- [x] Refactor `test_packages` out of `build_packages`
- [x] Fail `test_packages` if partial tests are run
- [x] Added a `final_status` job 
```