### PR TITLE
Ignore jupyter notebook form lang stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
Doesn't seem to work on the branch, maybe it works post merge to `develop`?