### PR TITLE
feat: modifications for revamped release process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
 
           echo "Current version: $VERSION"
 
-          LATEST_TAG=$(git tag -l 'v[0-9]*' | sort -V | tail -n 1)
+          LATEST_TAG=$(project version latest)
           if [ -z "$LATEST_TAG" ]; then
             echo "✓ No existing tags — version $VERSION is valid for initial release"
           else

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -71,7 +71,7 @@ jobs:
         if: steps.check_release.outputs.should_run == 'true'
         id: changelog
         run: |
-          LATEST_TAG=$(git tag -l 'v[0-9]*' | sort -V | tail -n 1)
+          LATEST_TAG=$(project version latest)
           echo "Latest tag: $LATEST_TAG"
           
           if [ -z "$LATEST_TAG" ]; then

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,127 @@
+name: Release PR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install "3.12"
+
+      - name: Setup project cli
+        run: |
+          make setup-project-cli
+
+      - name: Determine if release PR is needed
+        id: check_release
+        run: |
+          source .venv/bin/activate
+          # Check current release type
+          OUTPUT=$(project version get)
+          RELEASE_TYPE=$(echo "$OUTPUT" | grep '^RELEASE_TYPE:' | cut -d: -f2- | tr -d ' ')
+          VERSION=$(echo "$OUTPUT" | grep '^VERSION:' | cut -d: -f2- | tr -d ' ')
+          
+          echo "Current Version: $VERSION"
+          echo "Current Release Type: $RELEASE_TYPE"
+          
+          # Also check if HEAD has a tag
+          TAGS=$(git tag --points-at HEAD)
+          
+          if [[ "$RELEASE_TYPE" != "dev" ]]; then
+             echo "Version is not a dev version. Skipping release PR."
+             echo "should_run=false" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$TAGS" ]]; then
+             echo "Commit is already tagged: $TAGS. Skipping release PR."
+             echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+             echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version to stable
+        if: steps.check_release.outputs.should_run == 'true'
+        run: |
+          source .venv/bin/activate
+          project version bump --part stable
+          NEW_OUTPUT=$(project version get)
+          NEW_VERSION=$(echo "$NEW_OUTPUT" | grep '^VERSION:' | cut -d: -f2- | tr -d ' ')
+          echo "RELEASE_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+      - name: Update Lockfiles
+        if: steps.check_release.outputs.should_run == 'true'
+        run: |
+          source .venv/bin/activate
+          project venv lockfile --all
+
+      - name: Generate CHANGELOG
+        if: steps.check_release.outputs.should_run == 'true'
+        id: changelog
+        run: |
+          LATEST_TAG=$(git tag -l 'v[0-9]*' | sort -V | tail -n 1)
+          echo "Latest tag: $LATEST_TAG"
+          
+          if [ -z "$LATEST_TAG" ]; then
+             COMMITS=$(git log --pretty=format:"- %s" --no-merges)
+          else
+             COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" --no-merges)
+          fi
+          
+          # Prepare changelog section
+          DATE=$(date +%Y-%m-%d)
+          NEW_SECTION="## [v${RELEASE_VERSION}] (${DATE})\n\n### Changes\n${COMMITS}\n\n"
+          
+          # Write to body for PR
+          EOF=$(openssl rand -hex 8)
+          {
+            echo "pr_body<<$EOF"
+            echo -e "$NEW_SECTION"
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
+          
+          # Prepend to CHANGELOG.md (assuming there is a placeholder or just prepend to top)
+          echo -e "$NEW_SECTION" > new_changelog.tmp
+          if [ -f CHANGELOG.md ]; then
+             # assuming first line is # Changelog
+             head -n 1 CHANGELOG.md > CHANGELOG_FINAL.md
+             {
+               echo ""
+               cat new_changelog.tmp
+               tail -n +2 CHANGELOG.md
+             } >> CHANGELOG_FINAL.md
+             mv CHANGELOG_FINAL.md CHANGELOG.md
+          else
+             {
+               echo "# Changelog"
+               echo ""
+               cat new_changelog.tmp
+             } > CHANGELOG.md
+          fi
+          rm new_changelog.tmp
+
+      - name: Create Pull Request
+        if: steps.check_release.outputs.should_run == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to v${{ env.RELEASE_VERSION }} for release"
+          branch: "release/next"
+          title: "Release v${{ env.RELEASE_VERSION }}"
+          body: |
+            This is an automated release PR.
+            
+            ${{ steps.changelog.outputs.pr_body }}
+          labels: "release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 #   - workflow_dispatch   → dev (from develop) or rc (from release/vX.Y.Z)
 #
 # Release types and version formats:
-#   dev    (develop branch):         X.Y.Z-devN    e.g. 0.1.0-dev1
+#   dev    (main branch):            X.Y.Z-devN    e.g. 0.1.0-dev1
 #   rc     (release/vX.Y.Z branch):  X.Y.Z-rcN     e.g. 0.1.0-rc0
 #   stable (main branch):            X.Y.Z          e.g. 0.1.0
 
@@ -421,58 +421,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  sync_back:
-    name: Sync main → develop
-    runs-on: ubuntu-latest
-    needs: [setup, tag_and_release]
-    if: needs.setup.outputs.release_type == 'stable'
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
-      - name: Create PR main → develop
-        id: create_pr
-        env:
-          GH_TOKEN: ${{ secrets.GENAI_SHOP_ASST_REPO_PR_PAT }}
-        run: |
-          VERSION="${{ needs.setup.outputs.version }}"
-
-          # Check if a PR from main → develop already exists
-          EXISTING_PR=$(gh pr list \
-            --base develop --head main \
-            --json url --jq '.[0].url' 2>/dev/null || true)
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "PR already exists: $EXISTING_PR"
-            echo "pr_url=$EXISTING_PR" >> "$GITHUB_OUTPUT"
-          else
-            PR_URL=$(gh pr create \
-              --base develop \
-              --head main \
-              --title "chore: sync main → develop after v${VERSION} stable release" \
-              --body "Auto-generated PR to sync main back to develop after stable release v${VERSION}.")
-            echo "✓ Created PR: $PR_URL"
-            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Auto-merge PR
-        env:
-          GH_TOKEN: ${{ secrets.GENAI_SHOP_ASST_REPO_PR_PAT }}
-        run: |
-          gh pr merge "${{ steps.create_pr.outputs.pr_url }}" \
-            --merge --auto
-          echo "✓ Auto-merge enabled on PR"
-
-      - name: Delete release branch
-        env:
-          GH_TOKEN: ${{ secrets.GENAI_SHOP_ASST_REPO_PR_PAT }}
-        run: |
-          VERSION="${{ needs.setup.outputs.version }}"
-          RELEASE_BRANCH="release/v${VERSION}"
-          gh api --method DELETE \
-            "repos/${{ github.repository }}/git/refs/heads/${RELEASE_BRANCH}" \
-            && echo "✓ Deleted branch ${RELEASE_BRANCH}" \
-            || echo "⚠ Branch ${RELEASE_BRANCH} not found or already deleted"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ This document describes the release workflow for the GenAI Shopping Assistant mo
   - [Cutting a Release Branch](#-cutting-a-release-branch)
   - [RC Release](#-rc-release-from-releasevxyz)
   - [Stable Release](#-stable-release-from-main)
-  - [Post-Release Sync](#-post-release-sync-automatic)
+  - [Automated Release PRs](#-automated-release-prs-from-main)
 - [CI/CD Integration](#cicd-integration)
 - [Troubleshooting](#troubleshooting)
 - [Validation Rules](#validation-rules)
@@ -22,7 +22,7 @@ This document describes the release workflow for the GenAI Shopping Assistant mo
 ## Quick Overview
 
 ```
-develop branch
+main branch
     ↓
 Trigger: workflow_dispatch
 Tag: v0.1.0-dev.1 (no GitHub release)
@@ -48,9 +48,8 @@ Auto sync: PR main → develop, auto-merge, delete release branch
 
 | Branch | Purpose | Release Type | Version Format | Who Creates |
 |--------|---------|--------------|----------------|-------------|
-| `develop` | Ongoing development | dev | `X.Y.Z-dev.N` | team |
 | `release/vX.Y.Z` | Feature freeze, stabilization | rc | `X.Y.Z-rc.N` | release engineer |
-| `main` | Production-ready | stable | `X.Y.Z` | merge after RC approval |
+| `main` | Ongoing dev & Production-ready | dev / stable | `X.Y.Z-dev.N` / `X.Y.Z` | team / merge after RC approval |
 
 ---
 
@@ -151,11 +150,11 @@ Examples: 0.1.0-dev.0, 0.1.0-dev.1, 0.2.0-dev.0
 
 ## Release Types
 
-### 1️⃣ Dev Release (from `develop`)
+### 1️⃣ Dev Release (from `main`)
 
 **When to use**: Release a development snapshot for testing/CI purposes.
 
-**Trigger**: Manual (`workflow_dispatch`) on `develop` branch
+**Trigger**: Manual (`workflow_dispatch`) on `main` branch
 
 **Steps**:
 
@@ -180,7 +179,7 @@ Examples: 0.1.0-dev.0, 0.1.0-dev.1, 0.2.0-dev.0
 
 4. **Trigger release workflow**:
    - Go to **Actions** → **Release** → **Run workflow**
-   - Select branch: `develop`
+   - Select branch: `main`
    - Workflow will:
      - Validate version format (`X.Y.Z-dev.N`)
      - Create git tag `v0.1.0-dev.1`
@@ -200,10 +199,10 @@ Examples: 0.1.0-dev.0, 0.1.0-dev.1, 0.2.0-dev.0
 
 **Manual steps** (no automation):
 
-1. **Ensure `develop` is up-to-date**:
+1. **Ensure `main` is up-to-date**:
    ```bash
-   git checkout develop
-   git pull origin develop
+   git checkout main
+   git pull origin main
    ```
 
 2. **Create release branch**:
@@ -383,37 +382,27 @@ Examples: 0.1.0-dev.0, 0.1.0-dev.1, 0.2.0-dev.0
 
 ---
 
-### 5️⃣ Post-Release Sync (Automatic)
+### 5️⃣ Automated Release PRs (from `main`)
 
-**When**: Automatically triggered after stable release on `main`
+**When**: Automatically triggered on pushes to `main` that are not already tagged as a release.
 
 **What happens**:
 
-1. **Auto creates PR**: `main` → `develop`
-   - Title: `chore: sync main → develop after v0.1.0 stable release`
-   - Body: Auto-generated
+1. **Checks Version & Tags**:
+   - The workflow `.github/workflows/release-pr.yml` verifies if the current version is a `dev` release.
 
-2. **Auto-merges PR** (if no conflicts):
-   - Merge strategy: **normal merge commit** (not rebase, not squash)
-   - If conflicts exist: PR remains open for manual resolution
+2. **Generates Release Payload**:
+   - It automatically bumps the version to `stable` (`--part stable`).
+   - It generates a `CHANGELOG.md` payload with all commits since the last release tag.
+   - It updates all lockfiles.
 
-3. **Deletes release branch**:
-   - Deletes `release/v0.1.0`
-   - Keeps `main` and `develop` branches
+3. **Creates PR**:
+   - Opens an automated PR (e.g. `release/next` → `main`) titled `Release vX.Y.Z`.
+   - The PR body contains the generated changelog which can be manually refined before merging.
 
-**Manual action if needed**:
-```bash
-# If auto-merge failed due to conflicts
-git checkout develop
-git pull origin develop
-# ... resolve conflicts ...
-git add <files>
-git commit -m "chore: resolve release sync conflicts"
-git push origin develop
-
-# After manual sync, manually delete release branch
-git push origin --delete release/v0.1.0
-```
+**Result**:
+- ✅ Automated Release PR is opened.
+- ✅ Once merged into `main`, the stable release is automatically tagged and published by the main release workflow.
 
 ---
 
@@ -436,7 +425,7 @@ git push origin --delete release/v0.1.0
 **Service Image Builds in `build_services` Job**:
 - Builds Docker container images for services using Docker BuildKit
 - **Conditional**: Controlled via environment variable `SERVICES_BUILD_IMAGES`
-  - Always enabled on `develop` and `main` branches
+  - Always enabled on `main` and `main` branches
   - Optional on feature branches (disabled by default)
 - **Build features**:
   - Docker BuildKit support with inline cache (`BUILDKIT_INLINE_CACHE=1`)
@@ -452,13 +441,13 @@ git push origin --delete release/v0.1.0
 - **By default**: Runs `pytest -m "not slow"` (excludes slow tests)
 - **With `PACKAGES_RUN_ALL_TESTS` env var**: Runs all tests including slow ones
   - Set environment variable before pushing: `export PACKAGES_RUN_ALL_TESTS=true`
-  - Also enabled by default on `develop`, `main`, and `fix/develop-ci-tests-bug` branches
+  - Also enabled by default on `main`, `main`, and `fix/develop-ci-tests-bug` branches
 - Tests are run in a dedicated test venv (`.venv-test`)
 - **Fails if partial tests are run**: The job exits with code 1 if slow tests are skipped (PARTIAL), blocking the PR
 
 **Slow Test Marker**:
 Tests marked with `@pytest.mark.slow` are skipped on most branches by default, but included in:
-- Main workflow on `develop`, `main`, and `fix/develop-ci-tests-bug` branches (always run all tests)
+- Main workflow on `main`, `main`, and `fix/develop-ci-tests-bug` branches (always run all tests)
 - Release workflow (manual RC releases with `skip_slow_tests=FALSE`)
 - Release workflow (automated stable releases)
 
@@ -641,14 +630,14 @@ def test_long_running_operation():
 - ❌ Mismatch: `release/v0.1.0` + `0.2.0-rc0` → FAIL
 
 ### Q: Auto-sync PR can't auto-merge (conflicts)
-**A**: `develop` and `main` have diverged (unusual).
+**A**: `main` and `main` have diverged (unusual).
 - Manual merge required:
   ```bash
-  git checkout develop
-  git pull origin develop
+  git checkout main
+  git pull origin main
   git merge main
   # ... resolve conflicts ...
-  git push origin develop
+  git push origin main
   ```
 - Then manually delete release branch: `git push origin --delete release/vX.Y.Z`
 
@@ -684,7 +673,7 @@ All must have the **same version** (unified releasing).
   export PACKAGES_RUN_ALL_TESTS=true
   git push origin <branch>
   ```
-- Or if you're on `develop`, `main`, or `fix/develop-ci-tests-bug`, the tests should run automatically (all tests included)
+- Or if you're on `main`, `main`, or `fix/develop-ci-tests-bug`, the tests should run automatically (all tests included)
 
 ### Q: Release workflow failed — "Upstream workflow status: failure"
 **A**: The Main workflow must pass before the Release workflow can proceed.
@@ -718,8 +707,8 @@ The workflow enforces these rules (cannot be bypassed):
 - ✅ No duplicate tags allowed
 - ✅ Version in `pyproject.toml` must match the release type
 
-### Dev Release (`develop` branch)
-- ✅ Branch must be exactly `develop`
+### Dev Release (`main` branch)
+- ✅ Branch must be exactly `main`
 - ✅ Version format: `X.Y.Z-dev.N`
 
 ### RC Release (`release/vX.Y.Z` branch)
@@ -813,7 +802,7 @@ graph TD
 
 | Phase | Branch | Version | Trigger | GitHub Release | Service Images |
 |-------|--------|---------|---------|-----------------|---|
-| Development | `develop` | `X.Y.Z-dev.N` | Manual | ❌ No | ✅ Build & Push (with ENV) |
+| Development | `main` | `X.Y.Z-dev.N` | Manual | ❌ No | ✅ Build & Push (with ENV) |
 | Stabilization | `release/vX.Y.Z` | `X.Y.Z-rc.N` | Manual | ✅ Pre-release | ✅ Build & Push RC (with ENV) |
 | Production | `main` | `X.Y.Z` | Auto (push) | ✅ Stable | ✅ Build & Push stable + latest (with ENV) |
 | Sync | (auto) | (auto) | Auto | (auto) | (auto) |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -711,11 +711,11 @@ The workflow enforces these rules (cannot be bypassed):
 - ✅ Branch must be exactly `main`
 - ✅ Version format: `X.Y.Z-dev.N`
 
-### RC Release (`release/vX.Y.Z` branch)
+### Release Branch (`release/vX.Y.Z` branch)
 - ✅ Branch must match `release/v*`
-- ✅ Version format: `X.Y.Z-rc.N`
+- ✅ Version format: `X.Y.Z-rc.N` (during RC) or `X.Y.Z` (stable, just before merging)
 - ✅ Base version (`X.Y.Z`) must match branch version
-- ✅ CHANGELOG entry required: `[v0.1.0-rc.N]`
+- ✅ CHANGELOG entry required: `[vX.Y.Z-rc.N]` or `[vX.Y.Z]`
 
 ### Stable Release (`main` branch)
 - ✅ Branch must be exactly `main`
@@ -728,11 +728,12 @@ The workflow enforces these rules (cannot be bypassed):
 
 ```mermaid
 graph TD
-    subgraph develop["🔵 Develop Branch"]
-        D1["develop<br/>(ongoing development)"]
-        D2["Version: X.Y.Z-devN<br/>(manual edit)"]
-        D3["Commit with or without<br/>[include-slow-tests]"]
-        D1 --> D2 --> D3
+    subgraph main_dev["🔵 Main Branch (Dev)"]
+        D1["main<br/>(ongoing development)"]
+        D2["Version: X.Y.Z-dev.N<br/>(bump via cli)"]
+        D3["Push to main"]
+        D4["Auto Release PR<br/>(release/next)"]
+        D1 --> D2 --> D3 --> D4
     end
 
     subgraph release["🟡 Release Branch"]

--- a/packages/dummy-pkg/pyproject.toml
+++ b/packages/dummy-pkg/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dummy-pkg"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 
 requires-python = ">=3.12"
 

--- a/packages/dummy-pkg/uv.lock
+++ b/packages/dummy-pkg/uv.lock
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "dummy-pkg"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },

--- a/packages/project/pyproject.toml
+++ b/packages/project/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 description = "Monorepo CLI scripts and tools"
 requires-python = ">=3.12"
 dependencies = ["click>=8.1.7", "semver>=3.0.0", "tabulate>=0.9.0"]

--- a/packages/project/src/project/commands/version.py
+++ b/packages/project/src/project/commands/version.py
@@ -8,6 +8,7 @@ from project.core.version import (
     ALL_COMPONENTS,
     bump_versions,
     compare_versions,
+    get_latest_tag,
     get_release_info,
     get_version_info,
 )
@@ -27,6 +28,19 @@ def get():
         info = get_version_info(repo_root)
         click.echo(f"VERSION: {info.version}")
         click.echo(f"RELEASE_TYPE: {info.release_type}")
+    except Exception as e:
+        click.secho(f"Error: {e}", fg="red")
+        sys.exit(1)
+
+
+@version_cli.command()
+def latest():
+    """Get the latest semver tag from git."""
+    repo_root = get_repo_root()
+    try:
+        tag = get_latest_tag(repo_root)
+        if tag:
+            click.echo(tag)
     except Exception as e:
         click.secho(f"Error: {e}", fg="red")
         sys.exit(1)

--- a/packages/project/src/project/commands/version.py
+++ b/packages/project/src/project/commands/version.py
@@ -35,10 +35,17 @@ def get():
 @version_cli.command()
 @click.argument("new_version")
 @click.argument("old_version")
-def compare(new_version: str, old_version: str):
+@click.option(
+    "--no-enforce-unit-bump",
+    is_flag=True,
+    help="Do not enforce single unit bump restriction",
+)
+def compare(new_version: str, old_version: str, no_enforce_unit_bump: bool):
     """Assert new_version > old_version using semver semantics."""
     try:
-        result = compare_versions(new_version, old_version)
+        result = compare_versions(
+            new_version, old_version, enforce_unit_bump=not no_enforce_unit_bump
+        )
         if not result:
             click.secho(
                 f"Error: Version {new_version} must be greater than {old_version}",  # noqa: E501
@@ -79,7 +86,7 @@ def release_info_cmd(branch: str, test_release: bool):
 @click.option(
     "--part",
     required=True,
-    type=click.Choice(["major", "minor", "patch", "prerelease", "build"]),
+    type=click.Choice(["major", "minor", "patch", "prerelease", "build", "stable"]),
     help="Version part to bump",
 )
 @click.option("--prerelease-prefix", help="Prerelease prefix (e.g., rc, dev)")

--- a/packages/project/src/project/core/version.py
+++ b/packages/project/src/project/core/version.py
@@ -71,6 +71,15 @@ def bump_part(
     prerelease_prefix: str | None = None,
     allow_downgrade: bool = False,
 ) -> semver.Version:
+    if part == "stable":
+        if version.prerelease is None:
+            raise ValueError(f"Version {version} is already a stable release")
+        ver_dict = version.to_dict()
+        ver_dict["prerelease"] = None
+        ver_dict["build"] = None
+        next_version = semver.Version(**ver_dict)
+        return next_version
+
     is_prerelease = part == "prerelease"
 
     if is_prerelease:
@@ -189,14 +198,66 @@ def get_version_info(repo_root: Path) -> VersionInfo:
     return VersionInfo(version=version, release_type=release_type)
 
 
-def compare_versions(new_version: str, old_version: str) -> bool:
+def get_valid_next_versions(old_ver: semver.Version) -> set[semver.Version]:
+    valid = set()
+
+    if old_ver.prerelease:
+        # Increment existing prerelease
+        valid.add(old_ver.next_version("prerelease"))
+        # Upgrade to rc
+        ver_dict = old_ver.to_dict()
+        ver_dict["prerelease"] = "rc.0"
+        valid.add(semver.Version(**ver_dict))
+        # Upgrade to stable
+        ver_dict["prerelease"] = None
+        valid.add(semver.Version(**ver_dict))
+    else:
+        # New prerelease tracks
+        base_bumps = []
+        if old_ver.patch > 0:
+            base_bumps.append(old_ver.next_version("patch"))
+        elif old_ver.minor > 0:
+            base_bumps.append(old_ver.next_version("minor"))
+            base_bumps.append(old_ver.next_version("patch"))
+        else:
+            base_bumps.append(old_ver.next_version("major"))
+            base_bumps.append(old_ver.next_version("minor"))
+            base_bumps.append(old_ver.next_version("patch"))
+
+        for base in base_bumps:
+            valid.add(base)
+            b_dict = base.to_dict()
+            b_dict["prerelease"] = "dev.0"
+            valid.add(semver.Version(**b_dict))
+            b_dict["prerelease"] = "rc.0"
+            valid.add(semver.Version(**b_dict))
+
+    return valid
+
+
+def compare_versions(
+    new_version: str, old_version: str, enforce_unit_bump: bool = True
+) -> bool:
     try:
         new_ver = semver.Version.parse(new_version)
         old_ver = semver.Version.parse(old_version)
     except ValueError as e:
         raise ValueError(f"Invalid version: {e}") from e
 
-    return new_ver > old_ver
+    if new_ver <= old_ver:
+        raise ValueError(
+            f"New version {new_version} must be greater than {old_version}"
+        )
+
+    if enforce_unit_bump:
+        valid_next_versions = get_valid_next_versions(old_ver)
+        if new_ver not in valid_next_versions:
+            valid_strs = sorted(str(v) for v in valid_next_versions if v > old_ver)
+            raise ValueError(
+                f"Version {new_version} is not a valid single increment from {old_version}. "  # noqa: E501
+                f"Valid options are: {', '.join(valid_strs)}"
+            )
+    return True
 
 
 # TODO: Refactor this function to be more modular and testable
@@ -212,44 +273,52 @@ def get_release_info(  # noqa: C901
         return ReleaseInfo(version, tag_name, release_type, branch, test_release)
 
     if branch == "main":
-        if release_type != "stable":
+        if release_type not in ["dev", "stable"]:
             raise ValueError(
-                f"Main branch requires stable release type, got: {release_type}"
+                f"Main branch requires dev or stable release type, got: {release_type}"
             )
-        if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", version):
+        if release_type == "stable" and not re.match(
+            r"^[0-9]+\.[0-9]+\.[0-9]+$", version
+        ):
             raise ValueError(
                 f"Stable release requires X.Y.Z version format, got: {version}"
             )
-
-    elif re.match(r"^release/v[0-9]+\.[0-9]+\.[0-9]+$", branch):
-        if release_type != "rc":
-            raise ValueError(
-                f"Release branch requires rc release type, got: {release_type}"
-            )
-        if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$", version):
-            raise ValueError(
-                f"RC release requires X.Y.Z-rc.N version format, got: {version}"
-            )
-        base_version = version.split("-rc")[0]
-        branch_version = branch.replace("release/v", "")
-        if base_version != branch_version:
-            raise ValueError(
-                f"Version base {base_version} does not match branch version {branch_version}"  # noqa: E501
-            )
-
-    elif branch == "develop":
-        if release_type != "dev":
-            raise ValueError(
-                f"Develop branch requires dev release type, got: {release_type}"
-            )
-        if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$", version):
+        if release_type == "dev" and not re.match(
+            r"^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$", version
+        ):
             raise ValueError(
                 f"Dev release requires X.Y.Z-dev.N version format, got: {version}"
             )
 
+    elif branch.startswith("release/"):
+        if release_type not in ["rc", "stable"]:
+            raise ValueError(
+                f"Release branch requires rc or stable release type, got: {release_type}"  # noqa: E501
+            )
+        if release_type == "rc" and not re.match(
+            r"^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$", version
+        ):
+            raise ValueError(
+                f"RC release requires X.Y.Z-rc.N version format, got: {version}"
+            )
+        if release_type == "stable" and not re.match(
+            r"^[0-9]+\.[0-9]+\.[0-9]+$", version
+        ):
+            raise ValueError(
+                f"Stable release requires X.Y.Z version format, got: {version}"
+            )
+
+        if branch.startswith("release/v"):
+            branch_version = branch.replace("release/v", "")
+            base_version = version.split("-")[0]
+            if base_version != branch_version:
+                raise ValueError(
+                    f"Version base {base_version} does not match branch version {branch_version}"  # noqa: E501
+                )
+
     else:
         raise ValueError(
-            f"Releases can only be triggered from develop, release/vX.Y.Z, or main. Current branch: {branch}"  # noqa: E501
+            f"Releases can only be triggered from main or release/* branches. Current branch: {branch}"  # noqa: E501
         )
 
     return ReleaseInfo(version, tag_name, release_type, branch, test_release)

--- a/packages/project/src/project/core/version.py
+++ b/packages/project/src/project/core/version.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -388,3 +389,25 @@ def bump_versions(
             )
 
     return versions_components
+
+
+def get_latest_tag(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "tag", "-l", "v[0-9]*"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+    tags = [
+        t.strip()[1:] for t in result.stdout.splitlines() if t.strip().startswith("v")
+    ]
+    if not tags:
+        return None
+
+    tags.sort(key=semver.Version.parse)
+    return f"v{tags[-1]}"

--- a/packages/project/uv.lock
+++ b/packages/project/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "project"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/packages/shopping-assistant/pyproject.toml
+++ b/packages/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 
 requires-python = ">=3.12"
 

--- a/packages/shopping-assistant/uv.lock
+++ b/packages/shopping-assistant/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-monorepo"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 
 requires-python = ">=3.12"
 dependencies = ["semver", "tabulate>=0.9.0", "project"]

--- a/services/ecom-backend/pyproject.toml
+++ b/services/ecom-backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecom-backend-service"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 
 requires-python = ">=3.12"
 

--- a/services/ecom-backend/uv.lock
+++ b/services/ecom-backend/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "ecom-backend-service"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/services/shopping-assistant/pyproject.toml
+++ b/services/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-service"
-version = "0.1.0"
+version = "0.1.1-dev.0"
 
 requires-python = ">=3.12"
 

--- a/services/shopping-assistant/uv.lock
+++ b/services/shopping-assistant/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { directory = "../../packages/shopping-assistant" }
 dependencies = [
     { name = "click" },
@@ -2646,7 +2646,7 @@ test = [
 
 [[package]]
 name = "shopping-assistant-service"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ wheels = [
 
 [[package]]
 name = "project"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { directory = "packages/project" }
 dependencies = [
     { name = "click" },
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant-monorepo"
-version = "0.1.0"
+version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "project" },


### PR DESCRIPTION
# PR Summary: Revamp Release Process

This PR modernizes and streamlines our repository's release pipeline, pivoting away from a dual `main`/`develop` branch system to a simpler, more robust single-branch model focused on `main`.

## Key Changes

1. **Single-Branch Model**: 
   - Eliminated the `develop` branch. `main` now serves as the primary development branch.
   - The post-release `sync_back` automated job (which used to sync `main` into `develop`) was completely removed, reducing CI clutter and sync conflicts.

2. **Automated Release PRs**: 
   - Created a new GitHub Actions workflow (`release-pr.yml`) that triggers automatically on pushes to `main`. 
   - When it detects new commits on a `-dev` version, it automatically generates a Pull Request mapping out the next `stable` release, including an auto-generated `CHANGELOG.md` delta, version bumps, and unified lockfile updates.

3. **Robust Version Bumping & SemVer Enforcement**:
   - The core `version.py` script was heavily updated to ensure strict, logical single-increment version bumps based on the least-significant non-zero component. (e.g., `0.1.1` can only bump to `0.1.2`, but `0.1.0` can bump to `0.2.0` or `0.1.1`).
   - The `--part release` alias was consolidated into `--part stable` to clean up the CLI options.
   - Bumping validations can be selectively ignored via the new `--no-enforce-unit-bump` flag.

4. **Reliable Tag Resolution**:
   - Replaced fragile shell-based `sort -V` logic (which incorrectly treated `-rc.X` strings) with a robust Python one-liner powered by the `semver` library via a new `project version latest` command.
   - This ensures the `LATEST_TAG` resolves correctly when comparing stable versions against pre-releases across all workflows.

5. **Updated Documentation**:
   - Overhauled `RELEASING.md` and related workflow comments to comprehensively reflect the new single `main` branch paradigms.
