### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.1.1] (2026-05-29)
+
+### Changes
+- ci: fix gh api graphql variable expansion issue in release trigger (#312)
+- fix: release process (auto trigger, changelog generation) (#309)
+- fix: release-pr GH TOKEN fix, update ga step to peter-evans/create-pull-request@v8 (#306)
+- fix: release-pr auto triggering, and CHANGELOG CI generation (#305)
+- feat: modifications for revamped release process (#304)
+- release: `v0.1.0`: Merge back to develop (#302)
+
+
+
 ## [v0.1.0] - 2026-05-27
 
 ### 1st Release 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 ## [v0.1.1] (2026-05-29)
 
 ### Changes
-- ci: fix gh api graphql variable expansion issue in release trigger (#312)
-- fix: release process (auto trigger, changelog generation) (#309)
-- fix: release-pr GH TOKEN fix, update ga step to peter-evans/create-pull-request@v8 (#306)
-- fix: release-pr auto triggering, and CHANGELOG CI generation (#305)
-- feat: modifications for revamped release process (#304)
-- release: `v0.1.0`: Merge back to develop (#302)
 
+#### Revamped release process
 
+- Migrated to a single-branch model on `main`, removing `develop` branch and sync-back automation. (#302, #304)
+- Created `release-pr.yml` workflow to generate pull requests, version bumps, and changelogs. (#304)
+- Added workflow gating to skip stable release steps on development or release-candidate pushes. (#305)
+- Configured main workflow to dispatch release workflows upon merging release branches. (#309, #312)
+- Updated version script to validate version increments, added `--part stable`, and added bypass flag. (#304)
+- Integrated `semver` package for tag checks and updated changelog search for squashed commits. (#304, #309)
+- Corrected GraphQL query variable expansion in release trigger and resolved virtual environment paths in runner jobs. (#305, #312)
+- Updated runner step to `peter-evans/create-pull-request@v8` and corrected credentials. (#306)
 
 ## [v0.1.0] - 2026-05-27
 

--- a/packages/dummy-pkg/pyproject.toml
+++ b/packages/dummy-pkg/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dummy-pkg"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 
 requires-python = ">=3.12"
 

--- a/packages/dummy-pkg/uv.lock
+++ b/packages/dummy-pkg/uv.lock
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "dummy-pkg"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },

--- a/packages/project/pyproject.toml
+++ b/packages/project/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 description = "Monorepo CLI scripts and tools"
 requires-python = ">=3.12"
 dependencies = ["click>=8.1.7", "semver>=3.0.0", "tabulate>=0.9.0"]

--- a/packages/project/uv.lock
+++ b/packages/project/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "project"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/packages/shopping-assistant/pyproject.toml
+++ b/packages/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 
 requires-python = ">=3.12"
 

--- a/packages/shopping-assistant/uv.lock
+++ b/packages/shopping-assistant/uv.lock
@@ -3437,7 +3437,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-monorepo"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 
 requires-python = ">=3.12"
 dependencies = ["semver", "tabulate>=0.9.0", "project"]

--- a/services/ecom-backend/pyproject.toml
+++ b/services/ecom-backend/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecom-backend-service"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 
 requires-python = ">=3.12"
 

--- a/services/ecom-backend/uv.lock
+++ b/services/ecom-backend/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "ecom-backend-service"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/services/shopping-assistant/pyproject.toml
+++ b/services/shopping-assistant/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shopping-assistant-service"
-version = "0.1.1-dev.0"
+version = "0.1.1"
 
 requires-python = ">=3.12"
 

--- a/services/shopping-assistant/uv.lock
+++ b/services/shopping-assistant/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { directory = "../../packages/shopping-assistant" }
 dependencies = [
     { name = "click" },
@@ -2646,7 +2646,7 @@ test = [
 
 [[package]]
 name = "shopping-assistant-service"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ wheels = [
 
 [[package]]
 name = "project"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { directory = "packages/project" }
 dependencies = [
     { name = "click" },
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "shopping-assistant-monorepo"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "project" },


### PR DESCRIPTION
This is an automated release PR.

## [v0.1.1] (2026-05-29)

### Changes
- ci: fix gh api graphql variable expansion issue in release trigger (#312)
- fix: release process (auto trigger, changelog generation) (#309)
- fix: release-pr GH TOKEN fix, update ga step to peter-evans/create-pull-request@v8 (#306)
- fix: release-pr auto triggering, and CHANGELOG CI generation (#305)
- feat: modifications for revamped release process (#304)
- release: `v0.1.0`: Merge back to develop (#302)