### PR TITLE
Fix release process once again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -408,3 +408,37 @@ jobs:
         run: |
           echo "One or more jobs failed or were cancelled."
           exit 1
+
+      - name: Trigger Release Workflow
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GENAI_SHOP_ASST_REPO_PR_PAT }}
+        run: |
+          SHA="${{ github.sha }}"
+          echo "Checking if commit $SHA is a merge from a release branch..."
+          
+          # Use GraphQL to find the PR associated with this commit (works for squash merges too)
+          PR_HEAD=$(gh api graphql -F sha="$SHA" -F owner="${{ github.repository_owner }}" -F repo="${{ github.event.repository.name }}" -f query="
+            query($owner: String!, $repo: String!, $sha: String!) {
+              repository(owner: $owner, name: $repo) {
+                object(expression: $sha) {
+                  ... on Commit {
+                    associatedPullRequests(first: 1) {
+                      nodes {
+                        headRefName
+                      }
+                    }
+                  }
+                }
+              }
+            }" --jq ".data.repository.object.associatedPullRequests.nodes[0].headRefName // empty")
+            
+          echo "Associated PR head branch: $PR_HEAD"
+          
+          if [[ "$PR_HEAD" == release/* ]]; then
+            echo "✅ Release branch merge detected. Triggering release.yml..."
+            gh workflow run release.yml --ref main
+          else
+            echo "⏭️ Not a release branch merge. Skipping release trigger."
+          fi
+

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -78,7 +78,18 @@ jobs:
           if [ -z "$LATEST_TAG" ]; then
              COMMITS=$(git log --pretty=format:"- %s" --no-merges)
           else
-             COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" --no-merges)
+             # Get the actual commit the tag points to (falling back to HEAD if it fails somehow)
+             TAG_COMMIT=$(git rev-list -n 1 "$LATEST_TAG" || true)
+             
+             if [ -n "$TAG_COMMIT" ] && git merge-base --is-ancestor "$TAG_COMMIT" HEAD 2>/dev/null; then
+                 # If tag is an ancestor of HEAD, use standard range
+                 COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" --no-merges)
+             else
+                 # If tag is NOT an ancestor (e.g. was squashed, rebased, or orphaned)
+                 # Get the commit date of the tag and fetch commits after it
+                 TAG_DATE=$(git log -1 --format=%cI "$LATEST_TAG")
+                 COMMITS=$(git log --since="$TAG_DATE" --pretty=format:"- %s" --no-merges)
+             fi
           fi
           
           # Prepare changelog section

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,6 @@ jobs:
       version: ${{ steps.release_info.outputs.version }}
       tag_name: ${{ steps.release_info.outputs.tag_name }}
       release_type: ${{ steps.release_info.outputs.release_type }}
-      should_release: ${{ steps.release_info.outputs.should_release }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -184,18 +183,10 @@ jobs:
             echo "test_release=$TEST_RELEASE"
           } >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "$RELEASE_TYPE" != "stable" ]; then
-            echo "Auto-triggered release workflow only runs for stable releases. Current type is $RELEASE_TYPE. Skipping."
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          fi
-
   validate:
     name: Validate Release
     runs-on: ubuntu-latest
     needs: setup
-    if: needs.setup.outputs.should_release == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -249,7 +240,6 @@ jobs:
     name: Test Packages
     runs-on: ubuntu-latest
     needs: [check_upstream_workflow, setup, validate]
-    if: needs.setup.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -320,7 +310,6 @@ jobs:
       matrix:
         service: [ecom-backend, shopping-assistant]
     needs: [check_upstream_workflow, setup, validate, test_packages]
-    if: needs.setup.outputs.should_release == 'true'
     permissions:
       contents: read
       packages: write
@@ -369,7 +358,6 @@ jobs:
     name: Tag and Release
     runs-on: ubuntu-latest
     needs: [check_upstream_workflow, setup, validate, test_packages]
-    if: needs.setup.outputs.should_release == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,6 @@ name: Release
 #   stable (main branch):            X.Y.Z          e.g. 0.1.0
 
 on:
-  workflow_run:
-    workflows: ["Main workflow"]
-    types: [completed]
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       test_release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [UNRELEASED]
-
 ## [v0.1.0] - 2026-05-27
 
 ### 1st Release 🎉

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,7 +31,7 @@ Automated Release PR opened (branch: release/next, bumps version to 0.1.0)
     ↓
 Review and Merge Release PR to main
     ↓
-Trigger: push/merge to main
+Trigger: automatic (Main workflow detects release/* merge)
 Tag: v0.1.0 (stable release, GitHub Release created)
 ```
 
@@ -50,7 +50,7 @@ Fix bugs? → Bump rc.N, repeat
     ↓
 Bump to stable (0.1.0) on release branch and PR to main
     ↓
-Trigger: push to main (automatic via merge)
+Trigger: automatic (Main workflow detects release/* merge)
 Tag: v0.1.0 (stable release)
 ```
 
@@ -513,13 +513,13 @@ These artifacts are available for download in downstream workflows.
   - Useful when: doing RC releases while slow tests are being skipped in main workflow
 - Ensures both package builds and service image builds are complete (if enabled)
 
-### Graceful Gating for Automated Triggers
+### Smart Triggers for Releases
 
-The Release workflow (`release.yml`) is automatically triggered on the completion of the Main workflow on the `main` branch. However, to prevent premature or unauthorized stable releases from dev/prerelease versions:
+The Release workflow (`release.yml`) is automatically triggered via `workflow_dispatch` by the Main workflow itself upon successful completion, but **only** if the following conditions are met:
+- The push to `main` was a merge commit.
+- The merged PR's source branch started with `release/` (e.g. `release/next` or `release/v0.1.0`).
 
-- **Setup Job Gating**: The `setup` job executes a step to check the release type determined from the code version.
-- **Should Release Output**: If the workflow was auto-triggered via `workflow_run` on `main`, but the detected release type is **not** `stable` (e.g., it is a `dev` or `rc` release), the setup job outputs `should_release=false`.
-- **Job Gating**: All subsequent jobs (`validate`, `test_packages`, `retag_and_push_service_images`, and `tag_and_release`) are gated with `if: needs.setup.outputs.should_release == 'true'`. They will be gracefully skipped, ensuring no accidental tags or releases are generated on regular dev pushes.
+This ensures that the Release workflow is never unnecessarily triggered (and skipped) on standard `feat/*` or `fix/*` merges, keeping the GitHub Actions tab clean.
 
 ### Package Build & Artifact Flow
 
@@ -772,7 +772,7 @@ graph TD
         M1["main<br/>(production-ready)"]
         M2["Version: X.Y.Z<br/>(manual edit on release branch)"]
         M3["PR merge: release/vX.Y.Z → main"]
-        M4["Trigger: push to main (auto)"]
+        M4["Main workflow detects release/* merge"]
     end
 
     subgraph release_workflow["🔶 Release Workflow"]
@@ -786,8 +786,8 @@ graph TD
 
     D3 -->|push commit + Main workflow| MW1
     R3 -->|push commit + Main workflow| MW1
-    M4 -->|Main workflow completed| MW1
-    MW6 -->|Artifacts ready| R5
+    M3 -->|push commit| MW1
+    MW6 -->|Trigger release.yml| R5
 
     style D1 fill:#e3f2fd
     style R1 fill:#fff3e0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -717,7 +717,9 @@ The workflow enforces these rules (cannot be bypassed):
 - ✅ Branch must be exactly `main`
 - ✅ Version format: `X.Y.Z-dev.N`
 
-### Release Branch (`release/vX.Y.Z` or `release/next` branch)
+### Release Branch (`release/next` or `release/vX.Y.Z` branch)
+- **`release/next`**: Auto-generated branch for standard releases.
+- **`release/vX.Y.Z`**: Manual release branch created by developers for release candidate (RC) cycles. First RC releases are done here, and merging this to `main` creates the final stable release.
 - ✅ Branch must start with `release/`
 - ✅ Version format: `X.Y.Z-rc.N` (during RC) or `X.Y.Z` (stable, just before merging)
 - ✅ If branch starts with `release/v`, the base version (`X.Y.Z`) must match branch version


### PR DESCRIPTION
# PR Summary: Fix Release Process Workflow Issues

This PR resolves multiple bugs within the newly revamped release process to ensure reliable changelog generation and correct automatic workflow triggers.

## Key Changes

1. **Fixed CHANGELOG Generation** (`.github/workflows/release-pr.yml`):
   - Corrected the `git log` command logic in the `release-pr` workflow so that it accurately fetches commits only *since the last tag*.
   - Added robust fallbacks: if the latest tag is not an ancestor of `HEAD` (due to squash merges or rebasing), it now extracts the tag's commit date and safely uses `--since` to fetch subsequent commits without accidentally grabbing the entire repository history.
      - This may have happened due to the branch refactoring from `main`, `develop` -> `main`. 
      - 1st release being a merge commit on `main`, which was deleted, then `develop` was renamed to `main` 

2. **Fixed "Release" Workflow Auto-Trigger Logic** (`.github/workflows/main.yml`, `.github/workflows/release.yml`):
   - Removed the `workflow_run` trigger entirely from `release.yml` so it no longer auto-triggers on *every* push to `main` (which was causing downstream jobs to be skipped and cluttering the Actions UI).
   - Moved the detection logic directly into the `Main workflow`. The `main.yml` now utilizes the GitHub GraphQL API to reliably trace squash/merge commits back to their source PR branches (`headRefName`).
   - If the merged branch starts with `release/`, the `Main workflow` automatically calls `gh workflow run release.yml` via manual dispatch. Otherwise, nothing is triggered.

3. **Documentation Updates** (`RELEASING.md`):
   - Clarified the distinction between `release/next` (which is auto-generated) and `release/vX.Y.Z` (which are manual RC branches opened by developers).

4. **Cleanup** (`CHANGELOG.md`):
   - Simplified changelog format to easily append next release details at top of file.
