### PR TITLE
Fix GraphQL query variable expansion in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -418,7 +418,9 @@ jobs:
           echo "Checking if commit $SHA is a merge from a release branch..."
           
           # Use GraphQL to find the PR associated with this commit (works for squash merges too)
-          PR_HEAD=$(gh api graphql -F sha="$SHA" -F owner="${{ github.repository_owner }}" -F repo="${{ github.event.repository.name }}" -f query="
+          # Disable SC2016 warning as GraphQL query uses $ variables that shouldn't be expanded by Bash
+          # shellcheck disable=SC2016
+          PR_HEAD=$(gh api graphql -F sha="$SHA" -F owner="${{ github.repository_owner }}" -F repo="${{ github.event.repository.name }}" -f query='
             query($owner: String!, $repo: String!, $sha: String!) {
               repository(owner: $owner, name: $repo) {
                 object(expression: $sha) {
@@ -431,7 +433,7 @@ jobs:
                   }
                 }
               }
-            }" --jq ".data.repository.object.associatedPullRequests.nodes[0].headRefName // empty")
+            }' --jq ".data.repository.object.associatedPullRequests.nodes[0].headRefName // empty")
             
           echo "Associated PR head branch: $PR_HEAD"
           


### PR DESCRIPTION
# PR Summary: Fix GraphQL Query Variable Expansion Bug in Main Workflow

## Objective
Fix a bug in the final job (`final_status`) of the Main workflow (`.github/workflows/main.yml`) where triggering the release workflow fails because of shell variable expansion inside a double-quoted GraphQL query string.

## Problem Description
In the `Trigger Release Workflow` step of the `final_status` job:
- The `gh api graphql` command is used to query the repository for the associated pull request head branch.
- The query parameter `query="..."` was wrapped in double quotes.
- This allowed the local Bash shell running the runner script to evaluate GraphQL variables (like `$owner`, `$repo`, and `$sha`) as shell variables.
- Since these variables were undefined/empty in the shell environment, the query string was malformed, producing this GraphQL parsing error:
  ```
  gh: Expected VAR_SIGN, actual: COLON (":") at [2, 9]
  ```

## Proposed Changes
### Components & CI Configuration
* **CI Workflow Configuration**: `.github/workflows/main.yml`
  * Wrapped the GraphQL query payload inside single quotes (`'...'`) instead of double quotes (`"..."`).
  * This prevents Bash from interpolating standard GraphQL variable declarations (like `$owner`, `$repo`, and `$sha`) so they are passed cleanly to the GitHub GraphQL API.

## Verification Plan
### Automated Tests & Lint Checks
* Ran the pre-commit `actionlint` hook to ensure the workflow syntax is completely valid:
  ```bash
  pre-commit run --files .github/workflows/main.yml
  ```
  **Result**: `actionlint` passed successfully!

### Deployment & Flow Test
* Once merged, the `final_status` job will succeed and cleanly evaluate the merge origin branch to check if the commit came from a `release/` branch, triggering `release.yml` only when intended.
