### PR TITLE
fix: use project cli to get latest tag i release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
         run: |
           source .venv/bin/activate
           VERSION="${{ needs.setup.outputs.version }}"
-          LATEST_TAG=$(git tag -l 'v[0-9]*' | sort -V | tail -n 1)
+          LATEST_TAG=$(project version latest)
           if [ -z "$LATEST_TAG" ]; then
             echo "✓ No existing tags — version $VERSION is valid for initial release"
           else


### PR DESCRIPTION
- `release.yml` was still using older incorrect way of getting latest tag
- changed it to use `project version latest`
